### PR TITLE
Note about ALB support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ apig-wsgi
         :target: https://pypi.python.org/pypi/apig-wsgi
 
 Wrap a WSGI application in an AWS Lambda handler function for running on
-API Gateway.
+API Gateway or an ALB.
 
 A quick example:
 
@@ -43,11 +43,11 @@ Usage
 ``Flask()`` object.
 
 If you want to support sending binary responses, set ``binary_support`` to
-``True`` and make sure you have ``'*/*'`` in the 'binary media types'
-configuration on your Rest API on API Gateway. Note, whilst API Gateway
-supports a list of binary media types, using ``'*/*'`` is the best way to do
-it, since it is used to match the request 'Accept' header as well, which most
-applications ignore.
+``True``. ALB's support binary responses by default, but on API Gateway you
+need to make sure you have ``'*/*'`` in the 'binary media types' configuration
+on your Rest API (whilst API Gateway supports a list of binary media types,
+using ``'*/*'`` is the best way to do it, since it is used to match the request
+'Accept' header as well, which WSGI applications are likely to ignore).
 
 Note that binary responses aren't sent if your response has a 'Content-Type'
 starting 'text/html' or 'application/json' - this is to support sending larger

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with codecs.open('HISTORY.rst', 'r', 'utf-8') as history_file:
 setup(
     name='apig-wsgi',
     version=version,
-    description='Wrap a WSGI application in an AWS Lambda handler function for running on API Gateway.',
+    description='Wrap a WSGI application in an AWS Lambda handler function for running on API Gateway or an ALB.',
     long_description=readme + '\n\n' + history,
     author='Adam Johnson',
     author_email='me@adamj.eu',


### PR DESCRIPTION
The new ALB-Lambda integration [docs](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#receive-event-from-load-balancer) show that the same event format is used as API Gateway, so update library to describe its support.