### PR TITLE
Remove Python 2 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Use **pip**:
 
     pip install apig-wsgi
 
-Tested on Python versions 2.7 and 3.7.
+Python 3.4+ supported.
 
 Usage
 =====

--- a/apig_wsgi.py
+++ b/apig_wsgi.py
@@ -1,12 +1,7 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import sys
 from base64 import b64decode, b64encode
 from io import BytesIO
-
-import six
-from six.moves.urllib_parse import urlencode
+from urllib.parse import urlencode
 
 __author__ = 'Adam Johnson'
 __email__ = 'me@adamj.eu'
@@ -56,7 +51,7 @@ def get_environ(event, binary_support):
     }
 
     headers = event.get('headers') or {}  # may be None when testing on console
-    for key, value in six.iteritems(headers):
+    for key, value in headers.items():
         key = key.upper().replace('-', '_')
 
         if key == 'CONTENT_TYPE':

--- a/requirements.in
+++ b/requirements.in
@@ -1,11 +1,8 @@
 docutils
 flake8
 flake8-commas
-futures<3.2.0
 isort
-modernize
 multilint
 pygments
 pytest
 pytest-cov
-six

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,20 +6,14 @@
 #
 atomicwrites==1.2.1       # via pytest
 attrs==18.2.0             # via pytest
-configparser==3.7.1       # via flake8
 coverage==4.5.2           # via pytest-cov
 docutils==0.14
-enum34==1.1.6             # via flake8
 flake8-commas==2.0.0
 flake8==3.6.0
-funcsigs==1.0.2           # via pytest
-futures==3.1.1
 isort==4.3.4
 mccabe==0.6.1             # via flake8
-modernize==0.6.1
 more-itertools==5.0.0     # via pytest
 multilint==2.4.0
-pathlib2==2.3.3           # via pytest
 pluggy==0.8.1             # via pytest
 py==1.7.0                 # via pytest
 pycodestyle==2.4.0        # via flake8
@@ -27,5 +21,4 @@ pyflakes==2.0.0           # via flake8
 pygments==2.3.1
 pytest-cov==2.6.1
 pytest==4.1.1
-scandir==1.9.0            # via pathlib2
-six==1.12.0
+six==1.12.0               # via more-itertools, multilint, pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,11 +5,6 @@ universal = 1
 max_line_length = 120
 
 [isort]
-add_imports =
-    from __future__ import absolute_import
-    from __future__ import division
-    from __future__ import print_function
-    from __future__ import unicode_literals
 include_trailing_comma = True
 known_first_party = apig_wsgi
 line_length = 120

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,13 @@
 # -*- encoding:utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import codecs
 import re
 
 from setuptools import setup
 
 
 def get_version(filename):
-    with codecs.open(filename, 'r', 'utf-8') as fp:
+    with open(filename, 'r') as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
@@ -16,10 +15,10 @@ def get_version(filename):
 version = get_version('apig_wsgi.py')
 
 
-with codecs.open('README.rst', 'r', 'utf-8') as readme_file:
+with open('README.rst', 'r') as readme_file:
     readme = readme_file.read()
 
-with codecs.open('HISTORY.rst', 'r', 'utf-8') as history_file:
+with open('HISTORY.rst', 'r') as history_file:
     history = history_file.read()
 
 
@@ -33,10 +32,8 @@ setup(
     url='https://github.com/adamchainz/apig-wsgi',
     py_modules=['apig_wsgi'],
     include_package_data=True,
-    install_requires=[
-        'six',
-    ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    install_requires=[],
+    python_requires='>=3.4',
     license='ISC License',
     zip_safe=False,
     keywords='AWS, Lambda, API Gateway, APIG',
@@ -46,8 +43,6 @@ setup(
         'License :: OSI Approved :: ISC License (ISCL)',
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/test_apig_wsgi.py
+++ b/test_apig_wsgi.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from base64 import b64encode
 from io import BytesIO
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,10 @@
 [tox]
-envlist =
-    py{27,3},
-    py{27,3}-codestyle
+envlist = py3, py3-codestyle
 
 [testenv]
 install_command = pip install --no-deps {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
 commands = pytest {posargs}
-
-
-[testenv:py27-codestyle]
-# setup.py check broken on travis python 2.7
-commands = multilint --skip setup.py
-
 
 [testenv:py3-codestyle]
 commands = multilint


### PR DESCRIPTION
* Remove coding header and `__future__` imports
* Remove use of `six`
* In `setup.py`, remove use of `codecs.open`, stop requiring 'six' in `install_requires`, update `python_requires` and update `classifiers`
* In `README.rst`, update to "Python 3.4+ supported."
* In `requirements.in`,  remove `futures` pin, `modernize`, and `six`, and recompile
* In `tox.ini`, stop testing on Python 2
* In `setup.cfg`, remove isort's `add_imports` for `__future__` imports