### PR TITLE
Temporarily restore Python 2 support

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,11 @@ Pending Release
 
 .. Insert new release notes below this line
 
+* Temporarily restore Python 2 support. This is in order to fix a packaging
+  metadata issue that 2.0.0 was marked as supporting Python 2, so a new release
+  is needed with a higher version number for ``pip install apig-wsgi`` to
+  resolve properly on Python 2. Version 2.0.2+ of ``apig-wsgi`` will not
+  support Python 2.
 
 2.0.0 (2019-01-28)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Use **pip**:
 
     pip install apig-wsgi
 
-Python 3.4+ supported.
+Tested on Python versions 2.7 and 3.7.
 
 Usage
 =====

--- a/apig_wsgi.py
+++ b/apig_wsgi.py
@@ -1,7 +1,12 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import sys
 from base64 import b64decode, b64encode
 from io import BytesIO
-from urllib.parse import urlencode
+
+import six
+from six.moves.urllib_parse import urlencode
 
 __author__ = 'Adam Johnson'
 __email__ = 'me@adamj.eu'
@@ -51,7 +56,7 @@ def get_environ(event, binary_support):
     }
 
     headers = event.get('headers') or {}  # may be None when testing on console
-    for key, value in headers.items():
+    for key, value in six.iteritems(headers):
         key = key.upper().replace('-', '_')
 
         if key == 'CONTENT_TYPE':
@@ -79,7 +84,7 @@ class Response(object):
 
     def start_response(self, status, response_headers, exc_info=None):
         if exc_info is not None:
-            raise exc_info[0](exc_info[1]).with_traceback(exc_info[2])
+            six.reraise(exc_info[0], exc_info[1], exc_info[2])
         self.status_code = status.split()[0]
         self.headers.extend(response_headers)
         return self.body.write

--- a/requirements.in
+++ b/requirements.in
@@ -1,8 +1,11 @@
 docutils
 flake8
 flake8-commas
+futures<3.2.0
 isort
+modernize
 multilint
 pygments
 pytest
 pytest-cov
+six

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,14 +6,20 @@
 #
 atomicwrites==1.2.1       # via pytest
 attrs==18.2.0             # via pytest
+configparser==3.7.1       # via flake8
 coverage==4.5.2           # via pytest-cov
 docutils==0.14
+enum34==1.1.6             # via flake8
 flake8-commas==2.0.0
 flake8==3.6.0
+funcsigs==1.0.2           # via pytest
+futures==3.1.1
 isort==4.3.4
 mccabe==0.6.1             # via flake8
+modernize==0.6.1
 more-itertools==5.0.0     # via pytest
 multilint==2.4.0
+pathlib2==2.3.3           # via pytest
 pluggy==0.8.1             # via pytest
 py==1.7.0                 # via pytest
 pycodestyle==2.4.0        # via flake8
@@ -21,4 +27,5 @@ pyflakes==2.0.0           # via flake8
 pygments==2.3.1
 pytest-cov==2.6.1
 pytest==4.1.1
-six==1.12.0               # via more-itertools, multilint, pytest
+scandir==1.9.0            # via pathlib2
+six==1.12.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,15 @@
+[bdist_wheel]
+universal = 1
+
 [flake8]
 max_line_length = 120
 
 [isort]
+add_imports =
+    from __future__ import absolute_import
+    from __future__ import division
+    from __future__ import print_function
+    from __future__ import unicode_literals
 include_trailing_comma = True
 known_first_party = apig_wsgi
 line_length = 120

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,14 @@
+# -*- encoding:utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import codecs
 import re
 
 from setuptools import setup
 
 
 def get_version(filename):
-    with open(filename, 'r') as fp:
+    with codecs.open(filename, 'r', 'utf-8') as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
@@ -12,10 +16,10 @@ def get_version(filename):
 version = get_version('apig_wsgi.py')
 
 
-with open('README.rst', 'r') as readme_file:
+with codecs.open('README.rst', 'r', 'utf-8') as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst', 'r') as history_file:
+with codecs.open('HISTORY.rst', 'r', 'utf-8') as history_file:
     history = history_file.read()
 
 
@@ -29,8 +33,10 @@ setup(
     url='https://github.com/adamchainz/apig-wsgi',
     py_modules=['apig_wsgi'],
     include_package_data=True,
-    install_requires=[],
-    python_requires='>=3.4',
+    install_requires=[
+        'six',
+    ],
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     license='ISC License',
     zip_safe=False,
     keywords='AWS, Lambda, API Gateway, APIG',
@@ -40,6 +46,8 @@ setup(
         'License :: OSI Approved :: ISC License (ISCL)',
         'Natural Language :: English',
         'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/test_apig_wsgi.py
+++ b/test_apig_wsgi.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import sys
 from base64 import b64encode
 from io import BytesIO

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,18 @@
 [tox]
-envlist = py3, py3-codestyle
+envlist =
+    py{27,3},
+    py{27,3}-codestyle
 
 [testenv]
 install_command = pip install --no-deps {opts} {packages}
 deps = -r{toxinidir}/requirements.txt
 commands = pytest {posargs}
+
+
+[testenv:py27-codestyle]
+# setup.py check broken on travis python 2.7
+commands = multilint --skip setup.py
+
 
 [testenv:py3-codestyle]
 commands = multilint


### PR DESCRIPTION
As per note in HISTORY, this is done in order to fix PyPI metadata.