### PR TITLE
Add support for authorization lambdas

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,10 @@ Pending Release
 
 .. Insert new release notes below this line
 
+* If API Gateway event includes ``requestContext``, for example for custom
+  authorizers, pass it in the WSGI ``environ`` as
+  ``apig_wsgi.request_context``.
+
 2.1.1 (2019-03-31)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -52,3 +52,7 @@ using ``'*/*'`` is the best way to do it, since it is used to match the request
 Note that binary responses aren't sent if your response has a 'Content-Type'
 starting 'text/html' or 'application/json' - this is to support sending larger
 text responses.
+
+If the event from API Gateway contains the ``requestContext`` key, for example
+from custom request authorizers, this will be available in the WSGI environ
+at the key ``apig_wsgi.request_context``.

--- a/apig_wsgi.py
+++ b/apig_wsgi.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from base64 import b64decode, b64encode
 from io import BytesIO
@@ -67,11 +68,10 @@ def get_environ(event, binary_support):
 
         environ['HTTP_' + key] = value
 
+    # Sends any extra context passed by a custom lambda authorizer
     request_context = event.get("requestContext") or {}
-    authorizer = request_context.get("authorizer") or {}
-    for key, value in authorizer.items():
-        key = key.upper().replace("-", "_")
-        environ["HTTP_X_AUTHORIZER_" + key] = value
+    if "authorizer" in request_context:
+        environ["AUTHORIZER"] = json.dumps(request_context["authorizer"])
 
     return environ
 

--- a/apig_wsgi.py
+++ b/apig_wsgi.py
@@ -1,4 +1,3 @@
-import json
 import sys
 from base64 import b64decode, b64encode
 from io import BytesIO
@@ -68,10 +67,8 @@ def get_environ(event, binary_support):
 
         environ['HTTP_' + key] = value
 
-    # Sends any extra context passed by a custom lambda authorizer
-    request_context = event.get("requestContext") or {}
-    if "authorizer" in request_context:
-        environ["AUTHORIZER"] = json.dumps(request_context["authorizer"])
+    # Pass the AWS requestContext to the application
+    environ['REQUEST_CONTEXT'] = event.get('requestContext')
 
     return environ
 

--- a/apig_wsgi.py
+++ b/apig_wsgi.py
@@ -68,7 +68,8 @@ def get_environ(event, binary_support):
         environ['HTTP_' + key] = value
 
     # Pass the AWS requestContext to the application
-    environ['REQUEST_CONTEXT'] = event.get('requestContext')
+    if 'requestContext' in event:
+        environ['apig_wsgi.request_context'] = event['requestContext']
 
     return environ
 

--- a/apig_wsgi.py
+++ b/apig_wsgi.py
@@ -67,6 +67,12 @@ def get_environ(event, binary_support):
 
         environ['HTTP_' + key] = value
 
+    request_context = event.get("requestContext") or {}
+    authorizer = request_context.get("authorizer") or {}
+    for key, value in authorizer.items():
+        key = key.upper().replace("-", "_")
+        environ["HTTP_X_AUTHORIZER_" + key] = value
+
     return environ
 
 

--- a/test_apig_wsgi.py
+++ b/test_apig_wsgi.py
@@ -1,4 +1,3 @@
-import json
 import sys
 from base64 import b64encode
 from io import BytesIO
@@ -213,11 +212,11 @@ def test_exc_info(simple_app):
     assert str(excinfo.value) == 'Example exception'
 
 
-def test_custom_authorizer(simple_app):
+def test_request_context(simple_app):
     context = {'authorizer': {'user': 'test@example.com'}}
     event = make_event()
     event['requestContext'] = context
 
     simple_app.handler(event, None)
 
-    assert json.loads(simple_app.environ['AUTHORIZER']) == context['authorizer']
+    assert simple_app.environ['REQUEST_CONTEXT'] == context

--- a/test_apig_wsgi.py
+++ b/test_apig_wsgi.py
@@ -21,7 +21,7 @@ def simple_app():
     yield app
 
 
-def make_event(method='GET', qs_params=None, headers=None, body='', binary=False):
+def make_event(method='GET', qs_params=None, headers=None, body='', binary=False, request_context=None):
     if headers is None:
         headers = {
             'Host': 'example.com',
@@ -33,11 +33,16 @@ def make_event(method='GET', qs_params=None, headers=None, body='', binary=False
         'queryStringParameters': qs_params,
         'headers': headers,
     }
+
     if binary:
         event['body'] = b64encode(body.encode('utf-8'))
         event['isBase64Encoded'] = True
     else:
         event['body'] = body
+
+    if request_context is not None:
+        event['requestContext'] = request_context
+
     return event
 
 
@@ -214,9 +219,8 @@ def test_exc_info(simple_app):
 
 def test_request_context(simple_app):
     context = {'authorizer': {'user': 'test@example.com'}}
-    event = make_event()
-    event['requestContext'] = context
+    event = make_event(request_context=context)
 
     simple_app.handler(event, None)
 
-    assert simple_app.environ['REQUEST_CONTEXT'] == context
+    assert simple_app.environ['apig_wsgi.request_context'] == context

--- a/test_apig_wsgi.py
+++ b/test_apig_wsgi.py
@@ -210,3 +210,12 @@ def test_exc_info(simple_app):
         simple_app.handler(make_event(), None)
 
     assert str(excinfo.value) == 'Example exception'
+
+
+def test_authorization_header(simple_app):
+    event = make_event()
+    event['requestContext'] = {'authorizer': {'user': 'test@example.com'}}
+
+    simple_app.handler(event, None)
+
+    assert simple_app.environ['HTTP_X_AUTHORIZER_USER'] == 'test@example.com'

--- a/test_apig_wsgi.py
+++ b/test_apig_wsgi.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from base64 import b64encode
 from io import BytesIO
@@ -212,10 +213,11 @@ def test_exc_info(simple_app):
     assert str(excinfo.value) == 'Example exception'
 
 
-def test_authorization_header(simple_app):
+def test_custom_authorizer(simple_app):
+    context = {'authorizer': {'user': 'test@example.com'}}
     event = make_event()
-    event['requestContext'] = {'authorizer': {'user': 'test@example.com'}}
+    event['requestContext'] = context
 
     simple_app.handler(event, None)
 
-    assert simple_app.environ['HTTP_X_AUTHORIZER_USER'] == 'test@example.com'
+    assert json.loads(simple_app.environ['AUTHORIZER']) == context['authorizer']


### PR DESCRIPTION
Custom lambda authorizers might return extra context information (e.g.: username) which might be needed at the backend.

With this PR, that context is captured and converted into HTTP headers.