### PR TITLE
Add support for passing extra environ

### DIFF
--- a/test_apig_wsgi.py
+++ b/test_apig_wsgi.py
@@ -224,3 +224,13 @@ def test_request_context(simple_app):
     simple_app.handler(event, None)
 
     assert simple_app.environ['apig_wsgi.request_context'] == context
+
+
+def test_extra_environ(simple_app):
+    event = make_event()
+    extra_environ = {'SCRIPT_NAME': 'test'}
+
+    simple_app.handler = make_lambda_handler(simple_app, extra_environ=extra_environ)
+    response = simple_app.handler(event, None)
+
+    assert simple_app.environ['SCRIPT_NAME'] == 'test'

--- a/test_apig_wsgi.py
+++ b/test_apig_wsgi.py
@@ -228,9 +228,14 @@ def test_request_context(simple_app):
 
 def test_extra_environ(simple_app):
     event = make_event()
-    extra_environ = {'SCRIPT_NAME': 'test'}
 
+    simple_app.handler = make_lambda_handler(simple_app)
+    simple_app.handler(event, None)
+
+    assert simple_app.environ['SCRIPT_NAME'] == ''
+
+    extra_environ = {'SCRIPT_NAME': 'test'}
     simple_app.handler = make_lambda_handler(simple_app, extra_environ=extra_environ)
-    response = simple_app.handler(event, None)
+    simple_app.handler(event, None)
 
     assert simple_app.environ['SCRIPT_NAME'] == 'test'


### PR DESCRIPTION
When deploying on AWS Lambda, API-Gateway stage name should eventually be added to `wsgi` environment [SCRIPT_NAME](https://www.python.org/dev/peps/pep-0333/#environ-variables), so the application knows the virtual root location.

Please let me know whether this way to do it fit @adamchainz, so I can update the documentation.
