### PR TITLE
Format code with Black

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,9 @@ apig-wsgi
 .. image:: https://img.shields.io/pypi/v/apig-wsgi.svg
         :target: https://pypi.python.org/pypi/apig-wsgi
 
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+    :target: https://github.com/python/black
+
 Wrap a WSGI application in an AWS Lambda handler function for running on
 API Gateway or an ALB.
 

--- a/apig_wsgi.py
+++ b/apig_wsgi.py
@@ -3,11 +3,11 @@ from base64 import b64decode, b64encode
 from io import BytesIO
 from urllib.parse import urlencode
 
-__author__ = 'Adam Johnson'
-__email__ = 'me@adamj.eu'
-__version__ = '2.2.0'
+__author__ = "Adam Johnson"
+__email__ = "me@adamj.eu"
+__version__ = "2.2.0"
 
-__all__ = ('make_lambda_handler',)
+__all__ = ("make_lambda_handler",)
 
 
 def make_lambda_handler(wsgi_app, binary_support=False):
@@ -15,61 +15,63 @@ def make_lambda_handler(wsgi_app, binary_support=False):
     Turn a WSGI app callable into a Lambda handler function suitable for
     running on API Gateway.
     """
+
     def handler(event, context):
         environ = get_environ(event, binary_support=binary_support)
         response = Response(binary_support=binary_support)
         result = wsgi_app(environ, response.start_response)
         response.consume(result)
         return response.as_apig_response()
+
     return handler
 
 
 def get_environ(event, binary_support):
-    method = event['httpMethod']
-    body = event.get('body', '') or ''
-    if event.get('isBase64Encoded', False):
+    method = event["httpMethod"]
+    body = event.get("body", "") or ""
+    if event.get("isBase64Encoded", False):
         body = b64decode(body)
     else:
-        body = body.encode('utf-8')
-    params = event.get('queryStringParameters') or {}
+        body = body.encode("utf-8")
+    params = event.get("queryStringParameters") or {}
 
     environ = {
-        'CONTENT_LENGTH': str(len(body)),
-        'HTTP': 'on',
-        'PATH_INFO': event['path'],
-        'QUERY_STRING': urlencode(params),
-        'REMOTE_ADDR': '127.0.0.1',
-        'REQUEST_METHOD': method,
-        'SCRIPT_NAME': '',
-        'SERVER_PROTOCOL': 'HTTP/1.1',
-        'wsgi.errors': sys.stderr,
-        'wsgi.input': BytesIO(body),
-        'wsgi.multiprocess': False,
-        'wsgi.multithread': False,
-        'wsgi.run_once': False,
-        'wsgi.version': (1, 0),
+        "CONTENT_LENGTH": str(len(body)),
+        "HTTP": "on",
+        "PATH_INFO": event["path"],
+        "QUERY_STRING": urlencode(params),
+        "REMOTE_ADDR": "127.0.0.1",
+        "REQUEST_METHOD": method,
+        "SCRIPT_NAME": "",
+        "SERVER_PROTOCOL": "HTTP/1.1",
+        "wsgi.errors": sys.stderr,
+        "wsgi.input": BytesIO(body),
+        "wsgi.multiprocess": False,
+        "wsgi.multithread": False,
+        "wsgi.run_once": False,
+        "wsgi.version": (1, 0),
     }
 
-    headers = event.get('headers') or {}  # may be None when testing on console
+    headers = event.get("headers") or {}  # may be None when testing on console
     for key, value in headers.items():
-        key = key.upper().replace('-', '_')
+        key = key.upper().replace("-", "_")
 
-        if key == 'CONTENT_TYPE':
-            environ['CONTENT_TYPE'] = value
-        elif key == 'HOST':
-            environ['SERVER_NAME'] = value
-        elif key == 'X_FORWARDED_FOR':
-            environ['REMOTE_ADDR'] = value.split(', ')[0]
-        elif key == 'X_FORWARDED_PROTO':
-            environ['wsgi.url_scheme'] = value
-        elif key == 'X_FORWARDED_PORT':
-            environ['SERVER_PORT'] = value
+        if key == "CONTENT_TYPE":
+            environ["CONTENT_TYPE"] = value
+        elif key == "HOST":
+            environ["SERVER_NAME"] = value
+        elif key == "X_FORWARDED_FOR":
+            environ["REMOTE_ADDR"] = value.split(", ")[0]
+        elif key == "X_FORWARDED_PROTO":
+            environ["wsgi.url_scheme"] = value
+        elif key == "X_FORWARDED_PORT":
+            environ["SERVER_PORT"] = value
 
-        environ['HTTP_' + key] = value
+        environ["HTTP_" + key] = value
 
     # Pass the AWS requestContext to the application
-    if 'requestContext' in event:
-        environ['apig_wsgi.request_context'] = event['requestContext']
+    if "requestContext" in event:
+        environ["apig_wsgi.request_context"] = event["requestContext"]
 
     return environ
 
@@ -94,33 +96,30 @@ class Response(object):
                 if data:
                     self.body.write(data)
         finally:
-            if hasattr(result, 'close'):
+            if hasattr(result, "close"):
                 result.close()
 
     def as_apig_response(self):
-        response = {
-            'statusCode': self.status_code,
-            'headers': dict(self.headers),
-        }
+        response = {"statusCode": self.status_code, "headers": dict(self.headers)}
 
         content_type = self._get_content_type()
-        should_send_binary = (
-            self.binary_support and (
-                content_type is None or
-                not content_type.startswith(('text/', 'application/json'))
-            )
+        should_send_binary = self.binary_support and (
+            content_type is None
+            or not content_type.startswith(("text/", "application/json"))
         )
 
         if should_send_binary:
-            response['isBase64Encoded'] = True
-            response['body'] = b64encode(self.body.getvalue()).decode('utf-8')
+            response["isBase64Encoded"] = True
+            response["body"] = b64encode(self.body.getvalue()).decode("utf-8")
         else:
-            response['body'] = self.body.getvalue().decode('utf-8')
+            response["body"] = self.body.getvalue().decode("utf-8")
 
         return response
 
     def _get_content_type(self):
-        content_type_headers = [v for k, v in self.headers if k.lower() == 'content-type']
+        content_type_headers = [
+            v for k, v in self.headers if k.lower() == "content-type"
+        ]
         if len(content_type_headers):
             return content_type_headers[-1]
         return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+target-version = ['py36']

--- a/requirements/py35.txt
+++ b/requirements/py35.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -65,9 +65,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py36.txt
+++ b/requirements/py36.txt
@@ -11,7 +11,7 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via flake8-bugbear, pytest
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -65,9 +65,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8

--- a/requirements/py37.txt
+++ b/requirements/py37.txt
@@ -4,6 +4,10 @@
 #
 #    ./compile.sh
 #
+appdirs==1.4.3 \
+    --hash=sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92 \
+    --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e \
+    # via black
 atomicwrites==1.3.0 \
     --hash=sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4 \
     --hash=sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6 \
@@ -11,7 +15,10 @@ atomicwrites==1.3.0 \
 attrs==19.1.0 \
     --hash=sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79 \
     --hash=sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399 \
-    # via pytest
+    # via black, flake8-bugbear, pytest
+black==19.3b0 ; python_version == "3.7.*" \
+    --hash=sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf \
+    --hash=sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c
 bleach==3.1.0 \
     --hash=sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16 \
     --hash=sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa \
@@ -24,6 +31,10 @@ chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
     # via requests
+click==7.0 \
+    --hash=sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13 \
+    --hash=sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7 \
+    # via black
 coverage==4.5.3 \
     --hash=sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9 \
     --hash=sha256:39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74 \
@@ -65,9 +76,9 @@ entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
     --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
     # via flake8
-flake8-commas==2.0.0 \
-    --hash=sha256:d3005899466f51380387df7151fb59afec666a0f4f4a2c6a8995b975de0f44b7 \
-    --hash=sha256:ee2141a3495ef9789a3894ed8802d03eff1eaaf98ce6d8653a7c573ef101935e
+flake8-bugbear==19.3.0 \
+    --hash=sha256:5070774b668be92c4312e5ca82748ddf4ecaa7a24ff062662681bb745c7896eb \
+    --hash=sha256:fef9c9826d14ec23187ae1edeb3c6513c4e46bf0e70d86bac38f7d9aabae113d
 flake8==3.7.7 \
     --hash=sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661 \
     --hash=sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8
@@ -146,6 +157,10 @@ six==1.12.0 \
     --hash=sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c \
     --hash=sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73 \
     # via bleach, packaging, pytest, readme-renderer
+toml==0.10.0 \
+    --hash=sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c \
+    --hash=sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e \
+    # via black
 tqdm==4.32.1 \
     --hash=sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab \
     --hash=sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b \

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,6 +1,7 @@
+black ; python_version == '3.7.*'
 docutils
 flake8
-flake8-commas
+flake8-bugbear
 isort
 multilint
 pygments

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,16 @@
 [flake8]
-max_line_length = 120
+max-line-length = 80
+select = C,E,F,W,B,B950
+ignore = E501,W503
 
 [isort]
 include_trailing_comma = True
+force_grid_wrap = 0
 known_first_party = apig_wsgi
-line_length = 120
-multi_line_output = 5
+line_length = 88
+multi_line_output = 3
 not_skip = __init__.py
+use_parentheses = True
 
 [metadata]
 license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -4,46 +4,46 @@ from setuptools import setup
 
 
 def get_version(filename):
-    with open(filename, 'r') as fp:
+    with open(filename, "r") as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
 
-version = get_version('apig_wsgi.py')
+version = get_version("apig_wsgi.py")
 
 
-with open('README.rst', 'r') as readme_file:
+with open("README.rst", "r") as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst', 'r') as history_file:
+with open("HISTORY.rst", "r") as history_file:
     history = history_file.read()
 
 
 setup(
-    name='apig-wsgi',
+    name="apig-wsgi",
     version=version,
-    description='Wrap a WSGI application in an AWS Lambda handler function for running on API Gateway or an ALB.',
-    long_description=readme + '\n\n' + history,
-    author='Adam Johnson',
-    author_email='me@adamj.eu',
-    url='https://github.com/adamchainz/apig-wsgi',
-    py_modules=['apig_wsgi'],
+    description="Wrap a WSGI application in an AWS Lambda handler function for running on API Gateway or an ALB.",
+    long_description=readme + "\n\n" + history,
+    author="Adam Johnson",
+    author_email="me@adamj.eu",
+    url="https://github.com/adamchainz/apig-wsgi",
+    py_modules=["apig_wsgi"],
     include_package_data=True,
     install_requires=[],
-    python_requires='>=3.5',
-    license='ISC License',
+    python_requires=">=3.5",
+    license="ISC License",
     zip_safe=False,
-    keywords='AWS, Lambda, API Gateway, APIG',
+    keywords="AWS, Lambda, API Gateway, APIG",
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: ISC License (ISCL)',
-        'Natural Language :: English',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: ISC License (ISCL)",
+        "Natural Language :: English",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
 )

--- a/test_apig_wsgi.py
+++ b/test_apig_wsgi.py
@@ -11,37 +11,42 @@ from apig_wsgi import make_lambda_handler
 def simple_app():
     def app(environ, start_response):
         app.environ = environ
-        start_response('200 OK', app.headers, app.exc_info)
+        start_response("200 OK", app.headers, app.exc_info)
         return BytesIO(app.response)
 
-    app.headers = [('Content-Type', 'text/plain')]
-    app.response = b'Hello World\n'
+    app.headers = [("Content-Type", "text/plain")]
+    app.response = b"Hello World\n"
     app.handler = make_lambda_handler(app)
     app.exc_info = None
     yield app
 
 
-def make_event(method='GET', qs_params=None, headers=None, body='', binary=False, request_context=None):
+def make_event(
+    method="GET",
+    qs_params=None,
+    headers=None,
+    body="",
+    binary=False,
+    request_context=None,
+):
     if headers is None:
-        headers = {
-            'Host': 'example.com',
-        }
+        headers = {"Host": "example.com"}
 
     event = {
-        'httpMethod': method,
-        'path': '/',
-        'queryStringParameters': qs_params,
-        'headers': headers,
+        "httpMethod": method,
+        "path": "/",
+        "queryStringParameters": qs_params,
+        "headers": headers,
     }
 
     if binary:
-        event['body'] = b64encode(body.encode('utf-8'))
-        event['isBase64Encoded'] = True
+        event["body"] = b64encode(body.encode("utf-8"))
+        event["isBase64Encoded"] = True
     else:
-        event['body'] = body
+        event["body"] = body
 
     if request_context is not None:
-        event['requestContext'] = request_context
+        event["requestContext"] = request_context
 
     return event
 
@@ -50,9 +55,9 @@ def test_get(simple_app):
     response = simple_app.handler(make_event(), None)
 
     assert response == {
-        'statusCode': 200,
-        'headers': {'Content-Type': 'text/plain'},
-        'body': 'Hello World\n',
+        "statusCode": 200,
+        "headers": {"Content-Type": "text/plain"},
+        "body": "Hello World\n",
     }
 
 
@@ -61,11 +66,7 @@ def test_get_missing_content_type(simple_app):
 
     response = simple_app.handler(make_event(), None)
 
-    assert response == {
-        'statusCode': 200,
-        'headers': {},
-        'body': 'Hello World\n',
-    }
+    assert response == {"statusCode": 200, "headers": {}, "body": "Hello World\n"}
 
 
 def test_get_binary_support_text(simple_app):
@@ -74,68 +75,68 @@ def test_get_binary_support_text(simple_app):
     response = simple_app.handler(make_event(), None)
 
     assert response == {
-        'statusCode': 200,
-        'headers': {'Content-Type': 'text/plain'},
-        'body': 'Hello World\n',
+        "statusCode": 200,
+        "headers": {"Content-Type": "text/plain"},
+        "body": "Hello World\n",
     }
 
 
 def test_get_binary_support_binary(simple_app):
     simple_app.handler = make_lambda_handler(simple_app, binary_support=True)
-    simple_app.headers = [('Content-Type', 'application/octet-stream')]
-    simple_app.response = b'\x13\x37'
+    simple_app.headers = [("Content-Type", "application/octet-stream")]
+    simple_app.response = b"\x13\x37"
 
     response = simple_app.handler(make_event(), None)
 
     assert response == {
-        'statusCode': 200,
-        'headers': {'Content-Type': 'application/octet-stream'},
-        'body': b64encode(b'\x13\x37').decode('utf-8'),
-        'isBase64Encoded': True,
+        "statusCode": 200,
+        "headers": {"Content-Type": "application/octet-stream"},
+        "body": b64encode(b"\x13\x37").decode("utf-8"),
+        "isBase64Encoded": True,
     }
 
 
 def test_get_binary_support_no_content_type(simple_app):
     simple_app.handler = make_lambda_handler(simple_app, binary_support=True)
     simple_app.headers = []
-    simple_app.response = b'\x13\x37'
+    simple_app.response = b"\x13\x37"
 
     response = simple_app.handler(make_event(), None)
 
     assert response == {
-        'statusCode': 200,
-        'headers': {},
-        'body': b64encode(b'\x13\x37').decode('utf-8'),
-        'isBase64Encoded': True,
+        "statusCode": 200,
+        "headers": {},
+        "body": b64encode(b"\x13\x37").decode("utf-8"),
+        "isBase64Encoded": True,
     }
 
 
 def test_post(simple_app):
-    event = make_event(method='POST', body='The World is Large')
+    event = make_event(method="POST", body="The World is Large")
 
     response = simple_app.handler(event, None)
 
-    assert simple_app.environ['wsgi.input'].read() == b'The World is Large'
-    assert simple_app.environ['CONTENT_LENGTH'] == str(len(b'The World is Large'))
+    assert simple_app.environ["wsgi.input"].read() == b"The World is Large"
+    assert simple_app.environ["CONTENT_LENGTH"] == str(len(b"The World is Large"))
     assert response == {
-        'statusCode': 200,
-        'headers': {'Content-Type': 'text/plain'},
-        'body': 'Hello World\n',
+        "statusCode": 200,
+        "headers": {"Content-Type": "text/plain"},
+        "body": "Hello World\n",
     }
 
 
 def test_post_binary_support(simple_app):
     simple_app.handler = make_lambda_handler(simple_app)
-    event = make_event(method='POST', body='dogfood', binary=True)
+    event = make_event(method="POST", body="dogfood", binary=True)
 
     response = simple_app.handler(event, None)
 
-    assert simple_app.environ['wsgi.input'].read() == b'dogfood'
-    assert simple_app.environ['CONTENT_LENGTH'] == str(len(b'dogfood'))
+    assert simple_app.environ["wsgi.input"].read() == b"dogfood"
+    assert simple_app.environ["CONTENT_LENGTH"] == str(len(b"dogfood"))
     assert response == {
-        'statusCode': 200,
-        'headers': {'Content-Type': 'text/plain'},
-        'body': 'Hello World\n',
+        "statusCode": 200,
+        "headers": {"Content-Type": "text/plain"},
+        "body": "Hello World\n",
     }
 
 
@@ -144,7 +145,7 @@ def test_querystring_none(simple_app):
 
     simple_app.handler(event, None)
 
-    assert simple_app.environ['QUERY_STRING'] == ''
+    assert simple_app.environ["QUERY_STRING"] == ""
 
 
 def test_querystring_empty(simple_app):
@@ -152,47 +153,49 @@ def test_querystring_empty(simple_app):
 
     simple_app.handler(event, None)
 
-    assert simple_app.environ['QUERY_STRING'] == ''
+    assert simple_app.environ["QUERY_STRING"] == ""
 
 
 def test_querystring_one(simple_app):
-    event = make_event(qs_params={'foo': 'bar'})
+    event = make_event(qs_params={"foo": "bar"})
 
     simple_app.handler(event, None)
 
-    assert simple_app.environ['QUERY_STRING'] == 'foo=bar'
+    assert simple_app.environ["QUERY_STRING"] == "foo=bar"
 
 
 def test_plain_header(simple_app):
-    event = make_event(headers={'Test-Header': 'foobar'})
+    event = make_event(headers={"Test-Header": "foobar"})
 
     simple_app.handler(event, None)
 
-    assert simple_app.environ['HTTP_TEST_HEADER'] == 'foobar'
+    assert simple_app.environ["HTTP_TEST_HEADER"] == "foobar"
 
 
 def test_special_headers(simple_app):
-    event = make_event(headers={
-        'Content-Type': 'text/plain',
-        'Host': 'example.com',
-        'X-Forwarded-For': '1.2.3.4, 5.6.7.8',
-        'X-Forwarded-Proto': 'https',
-        'X-Forwarded-Port': '123',
-    })
+    event = make_event(
+        headers={
+            "Content-Type": "text/plain",
+            "Host": "example.com",
+            "X-Forwarded-For": "1.2.3.4, 5.6.7.8",
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Port": "123",
+        }
+    )
 
     simple_app.handler(event, None)
 
-    assert simple_app.environ['CONTENT_TYPE'] == 'text/plain'
-    assert simple_app.environ['SERVER_NAME'] == 'example.com'
-    assert simple_app.environ['REMOTE_ADDR'] == '1.2.3.4'
-    assert simple_app.environ['wsgi.url_scheme'] == 'https'
-    assert simple_app.environ['SERVER_PORT'] == '123'
+    assert simple_app.environ["CONTENT_TYPE"] == "text/plain"
+    assert simple_app.environ["SERVER_NAME"] == "example.com"
+    assert simple_app.environ["REMOTE_ADDR"] == "1.2.3.4"
+    assert simple_app.environ["wsgi.url_scheme"] == "https"
+    assert simple_app.environ["SERVER_PORT"] == "123"
 
 
 def test_no_headers(simple_app):
     # allow headers to be missing from event
     event = make_event()
-    del event['headers']
+    del event["headers"]
 
     simple_app.handler(event, None)
 
@@ -200,27 +203,27 @@ def test_no_headers(simple_app):
 def test_headers_None(simple_app):
     # allow headers to be 'None' from APIG test console
     event = make_event()
-    event['headers'] = None
+    event["headers"] = None
 
     simple_app.handler(event, None)
 
 
 def test_exc_info(simple_app):
     try:
-        raise ValueError('Example exception')
+        raise ValueError("Example exception")
     except ValueError:
         simple_app.exc_info = sys.exc_info()
 
     with pytest.raises(ValueError) as excinfo:
         simple_app.handler(make_event(), None)
 
-    assert str(excinfo.value) == 'Example exception'
+    assert str(excinfo.value) == "Example exception"
 
 
 def test_request_context(simple_app):
-    context = {'authorizer': {'user': 'test@example.com'}}
+    context = {"authorizer": {"user": "test@example.com"}}
     event = make_event(request_context=context)
 
     simple_app.handler(event, None)
 
-    assert simple_app.environ['apig_wsgi.request_context'] == context
+    assert simple_app.environ["apig_wsgi.request_context"] == context


### PR DESCRIPTION
* Add black and flake8-bugbear - automatically picked up by multilint
* Add pyproject.toml black configuration to target Python 3.6
* Reconfigure isort and flake8
* Drop flake8-commas and rely on Black's trailing comma insertion only
* Run black on the code so lint passes
* Add README badge