### PR TITLE
Add support for custom non-binary content type prefixes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,6 +13,9 @@ Pending Release
   (`docs <https://docs.python.org/3.8/library/importlib.metadata.html#distribution-versions>`__ /
   `backport <https://pypi.org/project/importlib-metadata/>`__).
 * Update Python support to 3.5-3.8.
+* Add `application/vnd.api+json` to default non-binary content type prefixes.
+* Add support for custom non-binary content type prefixes. This lets you control
+  which content types should be treated as plain text when binary support is enabled.
 
 2.3.0 (2019-08-19)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,8 @@ Python 3.5-3.8 supported.
 Usage
 =====
 
-``make_lambda_handler(app, binary_support=False)``
---------------------------------------------------
+``make_lambda_handler(app, binary_support=False, non_binary_content_type_prefixes=None)``
+-----------------------------------------------------------------------------------------
 
 ``app`` should be a WSGI app, for example from Django's ``wsgi.py`` or Flask's
 ``Flask()`` object.
@@ -53,8 +53,10 @@ using ``'*/*'`` is the best way to do it, since it is used to match the request
 'Accept' header as well, which WSGI applications are likely to ignore).
 
 Note that binary responses aren't sent if your response has a 'Content-Type'
-starting 'text/html' or 'application/json' - this is to support sending larger
-text responses.
+starting 'text/', 'application/json' or 'application/vnd.api+json' - this
+is to support sending larger text responses. To support other content types
+than the ones specified above, you can set `non_binary_content_type_prefixes`
+to a list of content type prefixes of your choice.
 
 If the event from API Gateway contains the ``requestContext`` key, for example
 from custom request authorizers, this will be available in the WSGI environ

--- a/src/apig_wsgi.py
+++ b/src/apig_wsgi.py
@@ -5,16 +5,41 @@ from urllib.parse import urlencode
 
 __all__ = ("make_lambda_handler",)
 
+DEFAULT_NON_BINARY_CONTENT_TYPE_PREFIXES = (
+    "text/",
+    "application/json",
+    "application/vnd.api+json",
+)
 
-def make_lambda_handler(wsgi_app, binary_support=False):
+
+def make_lambda_handler(
+    wsgi_app, binary_support=False, non_binary_content_type_prefixes=None
+):
     """
     Turn a WSGI app callable into a Lambda handler function suitable for
     running on API Gateway.
+
+    Parameters
+    ----------
+    wsgi_app : function
+        WSGI Application callable
+    binary_support : bool
+        Whether to support returning APIG-compatible binary responses
+    non_binary_content_type_prefixes : tuple of str
+        Tuple of content type prefixes which should be considered "Non-Binary" when
+        `binray_support` is True. This prevents apig_wsgi from unexpectedly encoding
+        non-binary responses as binary.
     """
+    if non_binary_content_type_prefixes is None:
+        non_binary_content_type_prefixes = DEFAULT_NON_BINARY_CONTENT_TYPE_PREFIXES
+    non_binary_content_type_prefixes = tuple(non_binary_content_type_prefixes)
 
     def handler(event, context):
         environ = get_environ(event, binary_support=binary_support)
-        response = Response(binary_support=binary_support)
+        response = Response(
+            binary_support=binary_support,
+            non_binary_content_type_prefixes=non_binary_content_type_prefixes,
+        )
         result = wsgi_app(environ, response.start_response)
         response.consume(result)
         return response.as_apig_response()
@@ -73,11 +98,12 @@ def get_environ(event, binary_support):
 
 
 class Response(object):
-    def __init__(self, binary_support):
+    def __init__(self, binary_support, non_binary_content_type_prefixes):
         self.status_code = 500
         self.headers = []
         self.body = BytesIO()
         self.binary_support = binary_support
+        self.non_binary_content_type_prefixes = non_binary_content_type_prefixes
 
     def start_response(self, status, response_headers, exc_info=None):
         if exc_info is not None:
@@ -113,8 +139,7 @@ class Response(object):
             return False
 
         content_type = self._get_content_type()
-        non_binary_content_types = ("text/", "application/json")
-        if not content_type.startswith(non_binary_content_types):
+        if not content_type.startswith(self.non_binary_content_type_prefixes):
             return True
 
         content_encoding = self._get_content_encoding()

--- a/tests/test_apig_wsgi.py
+++ b/tests/test_apig_wsgi.py
@@ -6,6 +6,8 @@ import pytest
 
 from apig_wsgi import make_lambda_handler
 
+CUSTOM_NON_BINARY_CONTENT_TYPE_PREFIXES = ["test/custom", "application/vnd.custom"]
+
 
 @pytest.fixture()
 def simple_app():
@@ -21,8 +23,14 @@ def simple_app():
     yield app
 
 
-parametrize_text_content_type = pytest.mark.parametrize(
-    "text_content_type", ["text/plain", "text/html", "application/json"]
+parametrize_default_text_content_type = pytest.mark.parametrize(
+    "text_content_type",
+    ["text/plain", "text/html", "application/json", "application/vnd.api+json"],
+)
+
+
+parametrize_custom_text_content_type = pytest.mark.parametrize(
+    "text_content_type", CUSTOM_NON_BINARY_CONTENT_TYPE_PREFIXES
 )
 
 
@@ -74,9 +82,26 @@ def test_get_missing_content_type(simple_app):
     assert response == {"statusCode": 200, "headers": {}, "body": "Hello World\n"}
 
 
-@parametrize_text_content_type
-def test_get_binary_support_text(simple_app, text_content_type):
+@parametrize_default_text_content_type
+def test_get_binary_support_default_text_content_types(simple_app, text_content_type):
     simple_app.handler = make_lambda_handler(simple_app, binary_support=True)
+    simple_app.headers = [("Content-Type", text_content_type)]
+
+    response = simple_app.handler(make_event(), None)
+    assert response == {
+        "statusCode": 200,
+        "headers": {"Content-Type": text_content_type},
+        "body": "Hello World\n",
+    }
+
+
+@parametrize_custom_text_content_type
+def test_get_binary_support_custom_text_content_types(simple_app, text_content_type):
+    simple_app.handler = make_lambda_handler(
+        simple_app,
+        binary_support=True,
+        non_binary_content_type_prefixes=CUSTOM_NON_BINARY_CONTENT_TYPE_PREFIXES,
+    )
     simple_app.headers = [("Content-Type", text_content_type)]
 
     response = simple_app.handler(make_event(), None)
@@ -102,11 +127,36 @@ def test_get_binary_support_binary(simple_app):
     }
 
 
-@parametrize_text_content_type
-def test_get_binary_support_binary_text_with_gzip_content_encoding(
+@parametrize_default_text_content_type
+def test_get_binary_support_binary_default_text_with_gzip_content_encoding(
     simple_app, text_content_type
 ):
     simple_app.handler = make_lambda_handler(simple_app, binary_support=True)
+    simple_app.headers = [
+        ("Content-Type", text_content_type),
+        ("Content-Encoding", "gzip"),
+    ]
+    simple_app.response = b"\x13\x37"
+
+    response = simple_app.handler(make_event(), None)
+
+    assert response == {
+        "statusCode": 200,
+        "headers": {"Content-Type": text_content_type, "Content-Encoding": "gzip"},
+        "body": b64encode(b"\x13\x37").decode("utf-8"),
+        "isBase64Encoded": True,
+    }
+
+
+@parametrize_custom_text_content_type
+def test_get_binary_support_binary_custom_text_with_gzip_content_encoding(
+    simple_app, text_content_type
+):
+    simple_app.handler = make_lambda_handler(
+        simple_app,
+        binary_support=True,
+        non_binary_content_type_prefixes=CUSTOM_NON_BINARY_CONTENT_TYPE_PREFIXES,
+    )
     simple_app.headers = [
         ("Content-Type", text_content_type),
         ("Content-Encoding", "gzip"),


### PR DESCRIPTION
Fixes #90 

- Add optional `non_binary_content_type_prefixes` argument
  which allows users to control which content-type should be
  treated as plain text when binary support is enabled
- Register `application/vnd.api+json` to default non-binary content types
- Add tests