### PR TITLE
Provide an escape hatch to retrieve lambda context object.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 History
 =======
 
+Pending
+-------
+
+* Provide an escape hatch for retrieving AWS Lambda Context object
+  (`PR #122 <https://github.com/adamchainz/apig-wsgi/pull/122>`__).
+
 2.5.1 (2020-02-26)
 ------------------
 

--- a/src/apig_wsgi.py
+++ b/src/apig_wsgi.py
@@ -34,7 +34,7 @@ def make_lambda_handler(
     non_binary_content_type_prefixes = tuple(non_binary_content_type_prefixes)
 
     def handler(event, context):
-        environ = get_environ(event, binary_support=binary_support)
+        environ = get_environ(event, context, binary_support=binary_support)
         response = Response(
             binary_support=binary_support,
             non_binary_content_type_prefixes=non_binary_content_type_prefixes,
@@ -46,7 +46,7 @@ def make_lambda_handler(
     return handler
 
 
-def get_environ(event, binary_support):
+def get_environ(event, context, binary_support):
     method = event["httpMethod"]
     body = event.get("body", "") or ""
     if event.get("isBase64Encoded", False):
@@ -112,6 +112,7 @@ def get_environ(event, binary_support):
 
     # Pass the full event to the application as an escape hatch
     environ["apig_wsgi.full_event"] = event
+    environ["apig_wsgi.context"] = context
 
     return environ
 

--- a/tests/test_apig_wsgi.py
+++ b/tests/test_apig_wsgi.py
@@ -472,7 +472,7 @@ def test_full_event(simple_app):
 
 
 def test_context(simple_app):
-    context = Context(aws_request_id="test-request-id"
+    context = Context(aws_request_id="test-request-id")
 
     simple_app.handler(make_event(), context)
 

--- a/tests/test_apig_wsgi.py
+++ b/tests/test_apig_wsgi.py
@@ -472,7 +472,7 @@ def test_full_event(simple_app):
 
 
 def test_context(simple_app):
-    context = Context(aws_request_id="test-request-id")
+    context = ContextStub(aws_request_id="test-request-id")
 
     simple_app.handler(make_event(), context)
 

--- a/tests/test_apig_wsgi.py
+++ b/tests/test_apig_wsgi.py
@@ -80,6 +80,33 @@ def make_event(
     return event
 
 
+class ContextStub:
+    def __init__(
+        function_name="app",
+        function_version="$LATEST",
+        invoked_function_arn="arn:test:lambda:us-east-1:0123456789:function:app",
+        memory_limit_in_mb=128,
+        aws_request_id=None,
+        log_stream_name="app-group",
+        log_group_name="app-stream",
+        identity=None,
+        client_context=None,
+        remaining_time_in_millis=60,
+    ):
+        self.function_name = function_name
+        self.function_version = function_version
+        self.invoked_function_arn = invoked_function_arn
+        self.memory_limit_in_mb = memory_limit_in_mb
+        self.aws_request_id = aws_request_id
+        self.log_group_name = log_group_name
+        self.log_stream_name = log_stream_name
+        if identity:
+            self.identity = identity
+        if client_context:
+            self.client_context = client_context
+        self._remaining_time_in_millis = remaining_time_in_millis
+
+
 def test_get(simple_app):
     response = simple_app.handler(make_event(), None)
 
@@ -442,3 +469,11 @@ def test_full_event(simple_app):
     simple_app.handler(event, None)
 
     assert simple_app.environ["apig_wsgi.full_event"] == event
+
+
+def test_context(simple_app):
+    context = Context(aws_request_id="test-request-id"
+
+    simple_app.handler(make_event(), context)
+
+    assert simple_app.environ["apig_wsgi.context"] == context

--- a/tests/test_apig_wsgi.py
+++ b/tests/test_apig_wsgi.py
@@ -82,6 +82,7 @@ def make_event(
 
 class ContextStub:
     def __init__(
+        self,
         function_name="app",
         function_version="$LATEST",
         invoked_function_arn="arn:test:lambda:us-east-1:0123456789:function:app",


### PR DESCRIPTION
This pull requests adds an `apig_wsgi.context` key to the environment dictionary, as an escape hatch to be able to retrieve AWS Lambda context object downstream.

The use-case I have is that I am writing a middleware, utilizing [structlog](http://www.structlog.org/en/stable/), which would bind the Lambda request ID to the log messages (a bit more involved [django-structlog](https://github.com/jrobichaud/django-structlog/blob/master/django_structlog/middlewares/request.py#L38|django-structlog) middleware). This is useful in cases when I want to correlate and extract only lines related to one specific request. Currently, AFAIU, each layer of the stack (APIG, Lambda, code) emits its own request ID.

The tests now have `ContextStub` class, which mimics the [documented](https://docs.aws.amazon.com/lambda/latest/dg/python-context.html) Python context object.

Let me know if I can do anything to get this merged. Thanks!