### PR TITLE
Make it possible to use a custom logger

### DIFF
--- a/src/apig_wsgi.py
+++ b/src/apig_wsgi.py
@@ -12,8 +12,10 @@ DEFAULT_NON_BINARY_CONTENT_TYPE_PREFIXES = (
 
 
 def make_lambda_handler(
-    wsgi_app, binary_support=False, non_binary_content_type_prefixes=None,
-    wsgi_errors=sys.stderr
+    wsgi_app,
+    binary_support=False,
+    non_binary_content_type_prefixes=None,
+    wsgi_errors=sys.stderr,
 ):
     """
     Turn a WSGI app callable into a Lambda handler function suitable for
@@ -35,7 +37,9 @@ def make_lambda_handler(
     non_binary_content_type_prefixes = tuple(non_binary_content_type_prefixes)
 
     def handler(event, context):
-        environ = get_environ(event, context, binary_support=binary_support, wsgi_errors=wsgi_errors)
+        environ = get_environ(
+            event, context, binary_support=binary_support, wsgi_errors=wsgi_errors
+        )
         response = Response(
             binary_support=binary_support,
             non_binary_content_type_prefixes=non_binary_content_type_prefixes,

--- a/src/apig_wsgi.py
+++ b/src/apig_wsgi.py
@@ -13,7 +13,7 @@ DEFAULT_NON_BINARY_CONTENT_TYPE_PREFIXES = (
 
 def make_lambda_handler(
     wsgi_app, binary_support=False, non_binary_content_type_prefixes=None,
-    wsgi_errors=sys.stdout
+    wsgi_errors=sys.stderr
 ):
     """
     Turn a WSGI app callable into a Lambda handler function suitable for

--- a/tests/test_apig_wsgi.py
+++ b/tests/test_apig_wsgi.py
@@ -478,3 +478,25 @@ def test_context(simple_app):
     simple_app.handler(make_event(), context)
 
     assert simple_app.environ["apig_wsgi.context"] == context
+
+def test_default_wsgi_errors(simple_app):
+    simple_app.handler = make_lambda_handler(simple_app)
+
+    response = simple_app.handler(make_event(), None)
+
+    assert simple_app.environ["wsgi.errors"] == sys.stdout
+
+def test_override_wsgi_errors(simple_app):
+    class customLogger():
+        def write(self,data):
+            pass
+
+        def flush(self):
+            pass
+
+    errorsTo=errorFile()
+    simple_app.handler = make_lambda_handler(simple_app, wsgi_errors=errorsTo)
+    response = simple_app.handler(make_event(), None)
+
+    assert simple_app.environ["wsgi.errors"] == errorsTo
+

--- a/tests/test_apig_wsgi.py
+++ b/tests/test_apig_wsgi.py
@@ -479,6 +479,7 @@ def test_context(simple_app):
 
     assert simple_app.environ["apig_wsgi.context"] == context
 
+
 def test_default_wsgi_errors(simple_app):
     simple_app.handler = make_lambda_handler(simple_app)
 
@@ -486,17 +487,17 @@ def test_default_wsgi_errors(simple_app):
 
     assert simple_app.environ["wsgi.errors"] == sys.stderr
 
+
 def test_override_wsgi_errors(simple_app):
-    class customLogger():
-        def write(self,data):
+    class customLogger:
+        def write(self, data):
             pass
 
         def flush(self):
             pass
 
-    errorsTo=customLogger()
+    errorsTo = customLogger()
     simple_app.handler = make_lambda_handler(simple_app, wsgi_errors=errorsTo)
     response = simple_app.handler(make_event(), None)
 
     assert simple_app.environ["wsgi.errors"] == errorsTo
-

--- a/tests/test_apig_wsgi.py
+++ b/tests/test_apig_wsgi.py
@@ -484,7 +484,7 @@ def test_default_wsgi_errors(simple_app):
 
     response = simple_app.handler(make_event(), None)
 
-    assert simple_app.environ["wsgi.errors"] == sys.stdout
+    assert simple_app.environ["wsgi.errors"] == sys.stderr
 
 def test_override_wsgi_errors(simple_app):
     class customLogger():
@@ -494,7 +494,7 @@ def test_override_wsgi_errors(simple_app):
         def flush(self):
             pass
 
-    errorsTo=errorFile()
+    errorsTo=customLogger()
     simple_app.handler = make_lambda_handler(simple_app, wsgi_errors=errorsTo)
     response = simple_app.handler(make_event(), None)
 

--- a/tests/test_apig_wsgi.py
+++ b/tests/test_apig_wsgi.py
@@ -483,7 +483,7 @@ def test_context(simple_app):
 def test_default_wsgi_errors(simple_app):
     simple_app.handler = make_lambda_handler(simple_app)
 
-    response = simple_app.handler(make_event(), None)
+    simple_app.handler(make_event(), None)
 
     assert simple_app.environ["wsgi.errors"] == sys.stderr
 
@@ -498,6 +498,6 @@ def test_override_wsgi_errors(simple_app):
 
     errorsTo = customLogger()
     simple_app.handler = make_lambda_handler(simple_app, wsgi_errors=errorsTo)
-    response = simple_app.handler(make_event(), None)
+    simple_app.handler(make_event(), None)
 
     assert simple_app.environ["wsgi.errors"] == errorsTo


### PR DESCRIPTION
I am using apig_wsgi with bottle, and between the two of them I don't have a way to intercept log messages before they get sent to stderr. In lambda, that causes my exceptions to end up in multiple log records, and when I export my logs to kibana they become unusable.

This change will let me use the following code to fix that:

```
class CustomAdapter(logging.LoggerAdapter):
    def process(self, msg, kwargs):
        return msg.replace("\n","\r "), kwargs

class LoggerFileObject():
    def __init__(self, logger):
        self.logger = logger
    def write(self, msg):
        logger.warn(msg)
    def flush(self):
        pass

logger = CustomAdapter(logging.getLogger(), extra={})
logger.setLevel( logging.INFO )

...

def lambda_handler(event, context):
   global logger

   return make_lambda_handler(app,wsgi_errors=LoggerFileObject(logger))(event, context)
```

(my logger replaces the \n characters with \r, which makes them cloudwatch-friendly).