### PR TITLE
Add defaults to allow ELB Health Checks to pass through

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 History
 =======
 
+* Add defaults for ``SERVER_HOST``, ``SERVER_PORT`` and ``wsgi.url_scheme``.
+  This enables responding to `ELB health check events
+  <https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#enable-health-checks-lambda>`__,
+  which don't contain the relevant headers
+  (`Issue #155 <https://github.com/adamchainz/apig-wsgi/pull/155>`__).
+
 2.6.0 (2020-03-07)
 ------------------
 

--- a/src/apig_wsgi.py
+++ b/src/apig_wsgi.py
@@ -62,12 +62,15 @@ def get_environ(event, context, binary_support):
         "REQUEST_METHOD": method,
         "SCRIPT_NAME": "",
         "SERVER_PROTOCOL": "HTTP/1.1",
+        "SERVER_NAME": "",
+        "SERVER_PORT": "",
         "wsgi.errors": sys.stderr,
         "wsgi.input": BytesIO(body),
         "wsgi.multiprocess": False,
         "wsgi.multithread": False,
         "wsgi.run_once": False,
         "wsgi.version": (1, 0),
+        "wsgi.url_scheme": "http",
     }
 
     # Multi-value query strings need explicit activation on ALB

--- a/tests/test_apig_wsgi.py
+++ b/tests/test_apig_wsgi.py
@@ -472,6 +472,29 @@ def test_full_event(simple_app):
     assert simple_app.environ["apig_wsgi.full_event"] == event
 
 
+def test_elb_health_check(simple_app):
+    """
+    Check compatibility with health check events as per:
+    https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#enable-health-checks-lambda  # noqa: B950
+    """
+    event = {
+        "requestContext": {"elb": {"targetGroupArn": "..."}},
+        "httpMethod": "GET",
+        "path": "/",
+        "queryStringParameters": {},
+        "headers": {"user-agent": "ELB-HealthChecker/2.0"},
+        "body": "",
+        "isBase64Encoded": False,
+    }
+
+    simple_app.handler(event, None)
+
+    environ = simple_app.environ
+    assert environ["SERVER_NAME"] == ""
+    assert environ["SERVER_PORT"] == ""
+    assert environ["wsgi.url_scheme"] == "http"
+
+
 def test_context(simple_app):
     context = ContextStub(aws_request_id="test-request-id")
 


### PR DESCRIPTION
According to wsgi spec, the wsgi.url_scheme, SERVER_NAME and SERVER_PORT
should be specified.

When processing an AWS ELB Health Check, only the user-agent header is
passed so we need to fill in the missing information.

Fixes #155