### PR TITLE
Add Support for Multi-Value Headers in the Response Body

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,12 +1,7 @@
 History
 =======
 
-* Add support for ``multiValueHeaders`` in the response object.
-  The environment variable to determine if ``multiValueHeaders`` are present is provided is ``apig_wsgi.multivalue_headers``.
-  This is to enable `ELB/ ALB with Lambda targets with multivalue headers enabled
-  <https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#multi-value-headers-response>`__
-  to have multiple header values in the response object as well. Does not conflict with `API Gateway implementation
-  <https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format>`__.
+* Use multi-value headers in the response when given in the request.
   (`PR #157 <https://github.com/adamchainz/apig-wsgi/pull/157>`__).
 
 2.7.0 (2020-07-13)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,14 @@
 History
 =======
 
+* Add support for ``multiValueHeaders`` in the response object.
+  The environment variable to determine if ``multiValueHeaders`` are present is provided is ``apig_wsgi.multivalue_headers``.
+  This is to enable `ELB/ ALB with Lambda targets with multivalue headers enabled
+  <https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#multi-value-headers-response>`__
+  to have multiple header values in the response object as well. Does not conflict with `API Gateway implementation
+  <https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format>`__.
+  (`PR #157 <https://github.com/adamchainz/apig-wsgi/pull/157>`__).
+
 2.7.0 (2020-07-13)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,10 @@ Multiple values for headers and query parameters are supported. They are
 enabled automatically on API Gateway but need
 `explict activation on ALB's <https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#multi-value-headers>`__.
 
+Note that for ALB ``multiValueHeaders``, this changes the input and output of how headers are accessed
+from ``headers`` to ``multiValueHeaders``. To check if this is enabled for the current context, check for the
+WSGI environ key ``apig_wsgi.multivalue_headers`` with a boolean flag indicating if ``multiValueHeaders`` are enabled.
+
 Example
 =======
 

--- a/README.rst
+++ b/README.rst
@@ -71,13 +71,12 @@ If you need the
 `Lambda Context object <https://docs.aws.amazon.com/lambda/latest/dg/python-context.html>`__,
 it's available in the WSGI environ at the key ``apig_wsgi.context``.
 
-Multiple values for headers and query parameters are supported. They are
-enabled automatically on API Gateway but need
+Multiple values for request and response headers and query parameters are
+supported. They are enabled automatically on API Gateway but need
 `explict activation on ALB's <https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#multi-value-headers>`__.
-
-Note that for ALB ``multiValueHeaders``, this changes the input and output of how headers are accessed
-from ``headers`` to ``multiValueHeaders``. To check if this is enabled for the current context, check for the
-WSGI environ key ``apig_wsgi.multivalue_headers`` with a boolean flag indicating if ``multiValueHeaders`` are enabled.
+If you need to determine from within your application if multiple header values
+are enabled, you can can check the ``apgi_wsgi.multi_value_headers`` key in the
+WSGI environ, which is ``True`` if they are enabled and ``False`` otherwise.
 
 Example
 =======

--- a/example/app/requirements.txt
+++ b/example/app/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile
 #
-apig-wsgi==2.6.0          # via -r requirements.in
+apig-wsgi==2.8.0          # via -r requirements.in
 asgiref==3.2.7            # via django
 django==3.0.7             # via -r requirements.in
 pytz==2020.1              # via django

--- a/example/app/requirements.txt
+++ b/example/app/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile
 #
-apig-wsgi==2.8.0          # via -r requirements.in
+apig-wsgi==2.7.0          # via -r requirements.in
 asgiref==3.2.7            # via django
 django==3.0.7             # via -r requirements.in
 pytz==2020.1              # via django

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = apig-wsgi
-version = 2.8.0
+version = 2.7.0
 description = Wrap a WSGI application in an AWS Lambda handler function for running on API Gateway or an ALB.
 long_description = file: README.rst
 long_description_content_type = text/x-rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = apig-wsgi
-version = 2.7.0
+version = 2.8.0
 description = Wrap a WSGI application in an AWS Lambda handler function for running on API Gateway or an ALB.
 long_description = file: README.rst
 long_description_content_type = text/x-rst

--- a/src/apig_wsgi.py
+++ b/src/apig_wsgi.py
@@ -125,7 +125,12 @@ def get_environ(event, context, binary_support):
 
 
 class Response(object):
-    def __init__(self, binary_support, non_binary_content_type_prefixes, multi_value_header_support=False):
+    def __init__(
+        self,
+        binary_support,
+        non_binary_content_type_prefixes,
+        multi_value_header_support=False,
+    ):
         self.status_code = 500
         self.headers = []
         self.body = BytesIO()

--- a/src/apig_wsgi.py
+++ b/src/apig_wsgi.py
@@ -39,7 +39,7 @@ def make_lambda_handler(
         response = Response(
             binary_support=binary_support,
             non_binary_content_type_prefixes=non_binary_content_type_prefixes,
-            multi_value_header_support=environ["wsgi.multivalue_headers"],
+            multi_value_header_support=environ["apig_wsgi.multivalue_headers"],
         )
         result = wsgi_app(environ, response.start_response)
         response.consume(result)
@@ -73,7 +73,7 @@ def get_environ(event, context, binary_support):
         "wsgi.run_once": False,
         "wsgi.version": (1, 0),
         "wsgi.url_scheme": "http",
-        "wsgi.multivalue_headers": False,
+        "apig_wsgi.multivalue_headers": False,
     }
 
     # Multi-value query strings need explicit activation on ALB
@@ -91,7 +91,7 @@ def get_environ(event, context, binary_support):
     if "multiValueHeaders" in event:
         # may be None when testing on console
         headers = event["multiValueHeaders"] or {}
-        environ["wsgi.multivalue_headers"] = True
+        environ["apig_wsgi.multivalue_headers"] = True
     else:
         # may be None when testing on console
         single_headers = event.get("headers") or {}

--- a/src/apig_wsgi.py
+++ b/src/apig_wsgi.py
@@ -156,7 +156,7 @@ class Response(object):
 
     def as_apig_response(self):
         response = {"statusCode": self.status_code}
-        # If there is a requirement for multi-value headers, then return the headers in the response as expected
+        # Return multiValueHeaders as header if support is required
         if self.multi_value_header_support:
             headers = defaultdict(list)
             [headers[k].append(v) for k, v in self.headers]

--- a/tests/test_apig_wsgi.py
+++ b/tests/test_apig_wsgi.py
@@ -39,7 +39,7 @@ def make_event(
     qs_params=None,
     qs_params_multi=True,
     headers=None,
-    headers_multi=True,
+    headers_multi=False,
     body="",
     binary=False,
     request_context=None,
@@ -50,7 +50,6 @@ def make_event(
     event = {
         "httpMethod": method,
         "path": "/",
-        "multiValueHeaders": headers,
     }
 
     if qs_params_multi:
@@ -114,6 +113,15 @@ def test_get(simple_app):
     assert response == {
         "statusCode": 200,
         "headers": {"Content-Type": "text/plain"},
+        "body": "Hello World\n",
+    }
+
+def test_get_multivalue_header_support(simple_app):
+    response = simple_app.handler(make_event(headers_multi=True), None)
+
+    assert response == {
+        "statusCode": 200,
+        "multiValueHeaders": {"Content-Type": ["text/plain"]},
         "body": "Hello World\n",
     }
 
@@ -342,7 +350,7 @@ def test_plain_header(simple_app):
 
 
 def test_plain_header_single(simple_app):
-    event = make_event(headers={"Test-Header": ["foobar"]}, headers_multi=False)
+    event = make_event(headers={"Test-Header": ["foobar"]})
 
     simple_app.handler(event, None)
 
@@ -350,7 +358,7 @@ def test_plain_header_single(simple_app):
 
 
 def test_plain_header_multi(simple_app):
-    event = make_event(headers={"Test-Header": ["foo", "bar"]})
+    event = make_event(headers={"Test-Header": ["foo", "bar"]}, headers_multi=True)
 
     simple_app.handler(event, None)
 
@@ -430,7 +438,6 @@ def test_x_forwarded_port(simple_app):
 def test_no_headers(simple_app):
     # allow headers to be missing from event
     event = make_event()
-    del event["multiValueHeaders"]
 
     simple_app.handler(event, None)
 

--- a/tests/test_apig_wsgi.py
+++ b/tests/test_apig_wsgi.py
@@ -368,16 +368,6 @@ def test_plain_header_single(simple_app):
     assert simple_app.environ["HTTP_TEST_HEADER"] == "foobar"
 
 
-def test_plain_header_single_multiple(simple_app):
-    event = make_event(
-        headers={"Test-Header": ["foobar1", "foobar2"]}, headers_multi=False
-    )
-
-    simple_app.handler(event, None)
-
-    assert simple_app.environ["HTTP_TEST_HEADER"] == "foobar2"
-
-
 def test_plain_header_multi(simple_app):
     event = make_event(headers={"Test-Header": ["foo", "bar"]})
 

--- a/tests/test_apig_wsgi.py
+++ b/tests/test_apig_wsgi.py
@@ -122,7 +122,12 @@ def test_get_missing_content_type(simple_app):
 
     response = simple_app.handler(make_event(), None)
 
-    assert response == {"statusCode": 200, "multiValueHeaders": {}, "body": "Hello World\n"}
+    assert response == {
+        "statusCode": 200,
+        "multiValueHeaders": {},
+        "body": "Hello World\n",
+    }
+
 
 def test_get_single_header(simple_app):
     response = simple_app.handler(make_event(headers_multi=False), None)
@@ -132,6 +137,7 @@ def test_get_single_header(simple_app):
         "headers": {"Content-Type": "text/plain"},
         "body": "Hello World\n",
     }
+
 
 @parametrize_default_text_content_type
 def test_get_binary_support_default_text_content_types(simple_app, text_content_type):
@@ -193,7 +199,10 @@ def test_get_binary_support_binary_default_text_with_gzip_content_encoding(
 
     assert response == {
         "statusCode": 200,
-        "multiValueHeaders": {"Content-Type": [text_content_type], "Content-Encoding": ["gzip"]},
+        "multiValueHeaders": {
+            "Content-Type": [text_content_type],
+            "Content-Encoding": ["gzip"],
+        },
         "body": b64encode(b"\x13\x37").decode("utf-8"),
         "isBase64Encoded": True,
     }
@@ -218,7 +227,10 @@ def test_get_binary_support_binary_custom_text_with_gzip_content_encoding(
 
     assert response == {
         "statusCode": 200,
-        "multiValueHeaders": {"Content-Type": [text_content_type], "Content-Encoding": ["gzip"]},
+        "multiValueHeaders": {
+            "Content-Type": [text_content_type],
+            "Content-Encoding": ["gzip"],
+        },
         "body": b64encode(b"\x13\x37").decode("utf-8"),
         "isBase64Encoded": True,
     }
@@ -355,8 +367,11 @@ def test_plain_header_single(simple_app):
 
     assert simple_app.environ["HTTP_TEST_HEADER"] == "foobar"
 
+
 def test_plain_header_single_multiple(simple_app):
-    event = make_event(headers={"Test-Header": ["foobar1", "foobar2"]}, headers_multi=False)
+    event = make_event(
+        headers={"Test-Header": ["foobar1", "foobar2"]}, headers_multi=False
+    )
 
     simple_app.handler(event, None)
 


### PR DESCRIPTION
Currently, if `multiValueHeaders` is enabled in the request from an ELB/ ALB, the response will not return what is expected by the LoadBalancer. This fix will allow the LoadBalancer to understand the response as expected. See the official AWS documentation on this [here](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#multi-value-headers-response).

Changed:
* Added new `environ` param, "wsgi.multivalue_headers"
  * Will be set to `True` when the value is passed in the event
* Create logic based on the flag value of the above param:
  * If the flag "wsgi.multivalue_headers" is `False`, return `headers` in the body, with the last value in the list as the header being assigned (Same logic flow as before)
  * If the flag "wsgi.multivalue_headers" is `True`, return `multiValueHeaders` in the body as a dictionary of lists
* Update unit tests