### PR TITLE
Upgrade example app requirements

### DIFF
--- a/example/README.rst
+++ b/example/README.rst
@@ -4,7 +4,7 @@ Example Application
 Requirements
 ------------
 
-Python 3.6+ on your path.
+Python 3.8.
 
 The Application
 ---------------
@@ -22,7 +22,9 @@ We use vanilla venv, pip, and Django to run:
    cd app
    python -m venv venv
    source venv/bin/activate
+   python -m pip install -U pip wheel
    python -m pip install -r requirements.txt
+   python -m pip install -e ../..
    python manage.py runserver
 
 Open it at http://127.0.0.1:8000/
@@ -43,6 +45,7 @@ other requirements into it, and run the deployment playbook:
    cd deployment
    python -m venv venv
    source venv/bin/activate
+   python -m pip install -U pip wheel
    python -m pip install -r requirements.txt
    ansible-playbook playbook.yml
 

--- a/example/app/requirements.in
+++ b/example/app/requirements.in
@@ -1,2 +1,1 @@
-apig-wsgi
 django

--- a/example/app/requirements.txt
+++ b/example/app/requirements.txt
@@ -4,8 +4,7 @@
 #
 #    pip-compile
 #
-apig-wsgi==2.7.0          # via -r requirements.in
-asgiref==3.2.7            # via django
-django==3.0.7             # via -r requirements.in
+asgiref==3.2.10           # via django
+django==3.0.8             # via -r requirements.in
 pytz==2020.1              # via django
 sqlparse==0.3.1           # via django

--- a/example/deployment/requirements.txt
+++ b/example/deployment/requirements.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile
 #
-ansible==2.9.9            # via -r requirements.in
-awscli==1.18.79           # via -r requirements.in
-boto3==1.14.2             # via -r requirements.in
+ansible==2.9.10           # via -r requirements.in
+awscli==1.18.100          # via -r requirements.in
+boto3==1.14.23            # via -r requirements.in
 boto==2.49.0              # via -r requirements.in
-botocore==1.17.2          # via awscli, boto3, s3transfer
+botocore==1.17.23         # via awscli, boto3, s3transfer
 cffi==1.14.0              # via cryptography
 colorama==0.4.3           # via awscli
 cryptography==2.9.2       # via ansible
@@ -20,7 +20,7 @@ pyasn1==0.4.8             # via rsa
 pycparser==2.20           # via cffi
 python-dateutil==2.8.1    # via botocore
 pyyaml==5.3.1             # via ansible, awscli
-rsa==3.4.2                # via awscli
+rsa==4.5                  # via awscli
 s3transfer==0.3.3         # via awscli, boto3
 six==1.15.0               # via cryptography, python-dateutil
 urllib3==1.25.9           # via botocore


### PR DESCRIPTION
* Manually install local apig-wsgi for local development
* Require Python 3.8 because that's what the requirements are compiled against.