### PR TITLE
Unquote paths

### DIFF
--- a/src/apig_wsgi.py
+++ b/src/apig_wsgi.py
@@ -70,7 +70,7 @@ def get_environ_v1(event, context, binary_support):
     environ = {
         "CONTENT_LENGTH": str(len(body)),
         "HTTP": "on",
-        "PATH_INFO": urllib.parse.unquote(event["path"]),
+        "PATH_INFO": urllib.parse.unquote_plus(event["path"]),
         "REMOTE_ADDR": "127.0.0.1",
         "REQUEST_METHOD": event["httpMethod"],
         "SCRIPT_NAME": "",
@@ -140,7 +140,7 @@ def get_environ_v2(event, context, binary_support):
         "CONTENT_LENGTH": str(len(body)),
         "HTTP": "on",
         "HTTP_COOKIE": ";".join(event.get("cookies", ())),
-        "PATH_INFO": urllib.parse.unquote(http["path"]),
+        "PATH_INFO": urllib.parse.unquote_plus(http["path"]),
         "QUERY_STRING": event["rawQueryString"],
         "REMOTE_ADDR": http["sourceIp"],
         "REQUEST_METHOD": http["method"],

--- a/src/apig_wsgi.py
+++ b/src/apig_wsgi.py
@@ -70,7 +70,7 @@ def get_environ_v1(event, context, binary_support):
     environ = {
         "CONTENT_LENGTH": str(len(body)),
         "HTTP": "on",
-        "PATH_INFO": urllib.parse.unquote_plus(event["path"]),
+        "PATH_INFO": urllib.parse.unquote_to_bytes(event["path"]).decode('iso-8859-1'),
         "REMOTE_ADDR": "127.0.0.1",
         "REQUEST_METHOD": event["httpMethod"],
         "SCRIPT_NAME": "",
@@ -140,7 +140,7 @@ def get_environ_v2(event, context, binary_support):
         "CONTENT_LENGTH": str(len(body)),
         "HTTP": "on",
         "HTTP_COOKIE": ";".join(event.get("cookies", ())),
-        "PATH_INFO": urllib.parse.unquote_plus(http["path"]),
+        "PATH_INFO": urllib.parse.unquote_to_bytes(http["path"]).decode('iso-8859-1'),
         "QUERY_STRING": event["rawQueryString"],
         "REMOTE_ADDR": http["sourceIp"],
         "REQUEST_METHOD": http["method"],

--- a/src/apig_wsgi.py
+++ b/src/apig_wsgi.py
@@ -15,10 +15,7 @@ DEFAULT_NON_BINARY_CONTENT_TYPE_PREFIXES = (
 
 
 def make_lambda_handler(
-    wsgi_app,
-    binary_support=None,
-    non_binary_content_type_prefixes=None,
-    unquote_path=True,
+    wsgi_app, binary_support=None, non_binary_content_type_prefixes=None
 ):
     """
     Turn a WSGI app callable into a Lambda handler function suitable for
@@ -34,8 +31,6 @@ def make_lambda_handler(
         Tuple of content type prefixes which should be considered "Non-Binary" when
         `binray_support` is True. This prevents apig_wsgi from unexpectedly encoding
         non-binary responses as binary.
-    unquote_path : bool
-        Whether to unquote path associated to PATH_INFO
     """
     if non_binary_content_type_prefixes is None:
         non_binary_content_type_prefixes = DEFAULT_NON_BINARY_CONTENT_TYPE_PREFIXES
@@ -48,10 +43,7 @@ def make_lambda_handler(
             # Binary support deafults 'off' on version 1
             event_binary_support = binary_support or False
             environ = get_environ_v1(
-                event,
-                context,
-                binary_support=event_binary_support,
-                unquote_path=unquote_path,
+                event, context, binary_support=event_binary_support
             )
             response = V1Response(
                 binary_support=event_binary_support,
@@ -59,9 +51,7 @@ def make_lambda_handler(
                 multi_value_headers=environ["apig_wsgi.multi_value_headers"],
             )
         elif version == "2.0":
-            environ = get_environ_v2(
-                event, context, binary_support=binary_support, unquote_path=unquote_path
-            )
+            environ = get_environ_v2(event, context, binary_support=binary_support)
             response = V2Response(
                 binary_support=True,
                 non_binary_content_type_prefixes=non_binary_content_type_prefixes,
@@ -75,14 +65,12 @@ def make_lambda_handler(
     return handler
 
 
-def get_environ_v1(event, context, binary_support, unquote_path):
+def get_environ_v1(event, context, binary_support):
     body = get_body(event)
     environ = {
         "CONTENT_LENGTH": str(len(body)),
         "HTTP": "on",
-        "PATH_INFO": urllib.parse.unquote(event["path"], encoding="iso-8859-1")
-        if unquote_path
-        else event["path"],
+        "PATH_INFO": urllib.parse.unquote(event["path"], encoding="iso-8859-1"),
         "REMOTE_ADDR": "127.0.0.1",
         "REQUEST_METHOD": event["httpMethod"],
         "SCRIPT_NAME": "",
@@ -143,7 +131,7 @@ def get_environ_v1(event, context, binary_support, unquote_path):
     return environ
 
 
-def get_environ_v2(event, context, binary_support, unquote_path):
+def get_environ_v2(event, context, binary_support):
     body = get_body(event)
     headers = event["headers"]
     http = event["requestContext"]["http"]
@@ -152,9 +140,7 @@ def get_environ_v2(event, context, binary_support, unquote_path):
         "CONTENT_LENGTH": str(len(body)),
         "HTTP": "on",
         "HTTP_COOKIE": ";".join(event.get("cookies", ())),
-        "PATH_INFO": urllib.parse.unquote(http["path"], encoding="iso-8859-1")
-        if unquote_path
-        else http["path"],
+        "PATH_INFO": urllib.parse.unquote(http["path"], encoding="iso-8859-1"),
         "QUERY_STRING": event["rawQueryString"],
         "REMOTE_ADDR": http["sourceIp"],
         "REQUEST_METHOD": http["method"],

--- a/src/apig_wsgi.py
+++ b/src/apig_wsgi.py
@@ -70,7 +70,7 @@ def get_environ_v1(event, context, binary_support):
     environ = {
         "CONTENT_LENGTH": str(len(body)),
         "HTTP": "on",
-        "PATH_INFO": urllib.parse.unquote_to_bytes(event["path"]).decode('iso-8859-1'),
+        "PATH_INFO": urllib.parse.unquote_to_bytes(event["path"]).decode("iso-8859-1"),
         "REMOTE_ADDR": "127.0.0.1",
         "REQUEST_METHOD": event["httpMethod"],
         "SCRIPT_NAME": "",
@@ -140,7 +140,7 @@ def get_environ_v2(event, context, binary_support):
         "CONTENT_LENGTH": str(len(body)),
         "HTTP": "on",
         "HTTP_COOKIE": ";".join(event.get("cookies", ())),
-        "PATH_INFO": urllib.parse.unquote_to_bytes(http["path"]).decode('iso-8859-1'),
+        "PATH_INFO": urllib.parse.unquote_to_bytes(http["path"]).decode("iso-8859-1"),
         "QUERY_STRING": event["rawQueryString"],
         "REMOTE_ADDR": http["sourceIp"],
         "REQUEST_METHOD": http["method"],

--- a/src/apig_wsgi.py
+++ b/src/apig_wsgi.py
@@ -71,7 +71,6 @@ def get_environ_v1(event, context, binary_support):
     environ = {
         "CONTENT_LENGTH": str(len(body)),
         "HTTP": "on",
-        # Replace %xx escapes by their single-character equivalent
         "PATH_INFO": urllib.parse.unquote(event["path"]),
         "REMOTE_ADDR": "127.0.0.1",
         "REQUEST_METHOD": event["httpMethod"],

--- a/src/apig_wsgi.py
+++ b/src/apig_wsgi.py
@@ -67,7 +67,6 @@ def make_lambda_handler(
 
 def get_environ_v1(event, context, binary_support):
     body = get_body(event)
-
     environ = {
         "CONTENT_LENGTH": str(len(body)),
         "HTTP": "on",
@@ -136,9 +135,6 @@ def get_environ_v2(event, context, binary_support):
     body = get_body(event)
     headers = event["headers"]
     http = event["requestContext"]["http"]
-
-    # Replace %xx escapes by their single-character equivalent
-    path_info = urllib.parse.unquote(http["path"])
 
     environ = {
         "CONTENT_LENGTH": str(len(body)),

--- a/src/apig_wsgi.py
+++ b/src/apig_wsgi.py
@@ -1,9 +1,9 @@
 import sys
+import urllib
 from base64 import b64decode, b64encode
 from collections import defaultdict
 from io import BytesIO
 from urllib.parse import urlencode
-import urllib
 
 __all__ = ("make_lambda_handler",)
 

--- a/tests/test_apig_wsgi.py
+++ b/tests/test_apig_wsgi.py
@@ -68,6 +68,7 @@ class ContextStub:
 def make_v1_event(
     *,
     method="GET",
+    path="/",
     qs_params=None,
     qs_params_multi=True,
     headers=None,
@@ -82,7 +83,7 @@ def make_v1_event(
     event = {
         "version": "1.0",
         "httpMethod": method,
-        "path": "/",
+        "path": path,
     }
 
     if qs_params_multi:
@@ -285,6 +286,21 @@ class TestV1Events:
             "isBase64Encoded": False,
             "body": "Hello World\n",
         }
+
+    def test_path_unquoting(self, simple_app):
+        event = make_v1_event(path="/api/path%2Finfo")
+
+        simple_app.handler(event, None)
+
+        assert simple_app.environ["PATH_INFO"] == "/api/path/info"
+
+    def test_path_no_unquoting(self, simple_app):
+        simple_app.handler = make_lambda_handler(simple_app, unquote_path=False)
+        event = make_v1_event(path="/api/path%2Finfo")
+
+        simple_app.handler(event, None)
+
+        assert simple_app.environ["PATH_INFO"] == "/api/path%2Finfo"
 
     def test_querystring_none(self, simple_app):
         event = make_v1_event()
@@ -525,6 +541,7 @@ def make_v2_event(
     *,
     host="example.com",
     method="GET",
+    path="/",
     query_string=None,
     cookies=None,
     headers=None,
@@ -544,7 +561,7 @@ def make_v2_event(
         "requestContext": {
             "http": {
                 "method": method,
-                "path": "/",
+                "path": path,
                 "sourceIp": "1.2.3.4",
                 "protocol": "https",
             },
@@ -772,6 +789,21 @@ class TestV2Events:
         assert simple_app.environ["HTTP_X_FORWARDED_PROTO"] == "https"
         assert simple_app.environ["SERVER_PORT"] == "123"
         assert simple_app.environ["HTTP_X_FORWARDED_PORT"] == "123"
+
+    def test_path_unquoting(self, simple_app):
+        event = make_v2_event(path="/api/path%2Finfo")
+
+        simple_app.handler(event, None)
+
+        assert simple_app.environ["PATH_INFO"] == "/api/path/info"
+
+    def test_path_no_unquoting(self, simple_app):
+        simple_app.handler = make_lambda_handler(simple_app, unquote_path=False)
+        event = make_v2_event(path="/api/path%2Finfo")
+
+        simple_app.handler(event, None)
+
+        assert simple_app.environ["PATH_INFO"] == "/api/path%2Finfo"
 
 
 # unknown version test

--- a/tests/test_apig_wsgi.py
+++ b/tests/test_apig_wsgi.py
@@ -294,14 +294,6 @@ class TestV1Events:
 
         assert simple_app.environ["PATH_INFO"] == "/api/path/info"
 
-    def test_path_no_unquoting(self, simple_app):
-        simple_app.handler = make_lambda_handler(simple_app, unquote_path=False)
-        event = make_v1_event(path="/api/path%2Finfo")
-
-        simple_app.handler(event, None)
-
-        assert simple_app.environ["PATH_INFO"] == "/api/path%2Finfo"
-
     def test_querystring_none(self, simple_app):
         event = make_v1_event()
 
@@ -796,14 +788,6 @@ class TestV2Events:
         simple_app.handler(event, None)
 
         assert simple_app.environ["PATH_INFO"] == "/api/path/info"
-
-    def test_path_no_unquoting(self, simple_app):
-        simple_app.handler = make_lambda_handler(simple_app, unquote_path=False)
-        event = make_v2_event(path="/api/path%2Finfo")
-
-        simple_app.handler(event, None)
-
-        assert simple_app.environ["PATH_INFO"] == "/api/path%2Finfo"
 
 
 # unknown version test


### PR DESCRIPTION
It seems that there is an issue with path parameters which are not decoded before being passed to the WSGI application.
Looks like it is a common discussion when implementing WSGI adapter: https://github.com/benoitc/gunicorn/pull/1211

In my case I was receiving my path parameter still encoded in my Flask application.

Based on my researches, here is the fix.