### PR TITLE
Drop more Python 3.5 references

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 isolated_build = True
 envlist =
-    py{35,36,37,38,39}
+    py{36,37,38,39}
     py39-codestyle
 
 [testenv]


### PR DESCRIPTION
Missed in previous PR.
