### PR TITLE
Improve requirements/compile.py

### DIFF
--- a/requirements/compile.py
+++ b/requirements/compile.py
@@ -8,24 +8,35 @@ if __name__ == "__main__":
     os.chdir(Path(__file__).parent)
     os.environ["CUSTOM_COMPILE_COMMAND"] = "requirements/compile.py"
     os.environ.pop("PIP_REQUIRE_VIRTUALENV")
-    common_args = ["-m", "piptools", "compile", "--generate-hashes"] + sys.argv[1:]
+    common_args = [
+        "-m",
+        "piptools",
+        "compile",
+        "--generate-hashes",
+        "--allow-unsafe",
+    ] + sys.argv[1:]
     subprocess.run(
         ["python3.6", *common_args, "-o", "py36.txt"],
         check=True,
+        capture_output=True,
     )
     subprocess.run(
         ["python3.7", *common_args, "-o", "py37.txt"],
         check=True,
+        capture_output=True,
     )
     subprocess.run(
         ["python3.8", *common_args, "-o", "py38.txt"],
         check=True,
+        capture_output=True,
     )
     subprocess.run(
         ["python3.9", *common_args, "-o", "py39.txt"],
         check=True,
+        capture_output=True,
     )
     subprocess.run(
         ["python3.10", *common_args, "-o", "py310.txt"],
         check=True,
+        capture_output=True,
     )


### PR DESCRIPTION
* Adopt `--allow-unsafe` early
* Capture output to avoid terminal spam.
