### PR TITLE
Improve Flake8 config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,5 @@ source =
 show_missing = True
 
 [flake8]
-max-line-length = 80
-select = E,F,W,B,B950,C,I,TYP
-ignore = E203,E501,W503
+max-line-length = 88
+extend-ignore = E203

--- a/tests/test_apig_wsgi.py
+++ b/tests/test_apig_wsgi.py
@@ -542,7 +542,7 @@ class TestV1Events:
     def test_elb_health_check(self, simple_app: App) -> None:
         """
         Check compatibility with health check events as per:
-        https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#enable-health-checks-lambda  # noqa: B950
+        https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#enable-health-checks-lambda  # noqa: E501
         """
         event = {
             "requestContext": {"elb": {"targetGroupArn": "..."}},


### PR DESCRIPTION
Use only Black compat options. Removing 'select' declaration means that plugin error codes are selected by default.
