### PR TITLE
Confirm support for Lambda Function URL’s

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,16 +53,18 @@ Improve your skills with `one of my books <https://adamj.eu/books/>`__.
 Usage
 =====
 
-Use apig-wsgi in your lambda function that you attach to one of:
+Use apig-wsgi in your AWS Lambda Function that you attach to one of:
 
-* An ALB.
-* An API Gateway “REST API”.
-* An API Gateway “HTTP API”.
+* A `Lambda Function URL <https://docs.aws.amazon.com/lambda/latest/dg/lambda-urls.html>`__
+* An `API Gateway “HTTP API” <https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api.html>`__
+* An `API Gateway “REST API” <https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-rest-api.html>`__
+* An `ALB <https://docs.aws.amazon.com/lambda/latest/dg/services-alb.html>`__
+
 
 Both “format version 1” and “format version 2” are supported
 (`documentation <https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html>`__).
-apig-wsgi will automatically detect the version in use. At time of writing,
-“format version 2” is only supported on HTTP API’s.
+apig-wsgi will automatically detect the version in use.
+At time of writing, “format version 2” is used for Lambda Function URL’s and API Gateway HTTP API’s.
 
 ``make_lambda_handler(app, binary_support=None, non_binary_content_type_prefixes=None)``
 ----------------------------------------------------------------------------------------
@@ -117,5 +119,5 @@ WSGI environ, which is ``True`` if they are enabled and ``False`` otherwise.
 Example
 =======
 
-An example application with Ansible deployment is provided in the ``example/``
-directory in the repository. See the ``README.rst`` there for guidance.
+An example Django project with Ansible deployment is provided in the ``example/`` directory in the repository.
+See the ``README.rst`` there for guidance.

--- a/example/deployment/files/cloudformation_site.yml
+++ b/example/deployment/files/cloudformation_site.yml
@@ -48,21 +48,30 @@ Resources:
       Runtime: python3.9
       Timeout: 20
 
+  # Function URL
+
+  LambdaPermissionFunctionUrl:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunctionUrl
+      FunctionName: !GetAtt LambdaFunction.Arn
+      Principal: '*'
+      FunctionUrlAuthType: NONE
+
+  FunctionUrl:
+    Type: AWS::Lambda::Url
+    Properties:
+      TargetFunctionArn: !GetAtt LambdaFunction.Arn
+      AuthType: NONE
+
+  # New style HTTP API
+
   LambdaPermissionAPIGW:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !GetAtt LambdaFunction.Arn
       Principal: apigateway.amazonaws.com
-
-  LambdaPermissionALB:
-    Type: AWS::Lambda::Permission
-    Properties:
-      Action: lambda:InvokeFunction
-      FunctionName: !GetAtt LambdaFunction.Arn
-      Principal: elasticloadbalancing.amazonaws.com
-
-  # new style HTTP API
 
   HttpApi:
     Type: AWS::ApiGatewayV2::Api
@@ -79,7 +88,7 @@ Resources:
       Integration:
         PayloadFormatVersion: "2.0"
 
-  # old style REST API
+  # Old style REST API
 
   RestApi:
     Type: AWS::ApiGateway::RestApi
@@ -134,6 +143,13 @@ Resources:
 
   # ALB
 
+  LambdaPermissionALB:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt LambdaFunction.Arn
+      Principal: elasticloadbalancing.amazonaws.com
+
   LoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Condition: ShouldDeployAlb
@@ -181,8 +197,11 @@ Resources:
 
 Outputs:
 
+  FunctionUrl:
+    Value: !GetAtt FunctionUrl.FunctionUrl
+
   HttpApiUrl:
-    Value: !Sub https://${HttpApi}.execute-api.${AWS::Region}.amazonaws.com/
+    Value: !GetAtt HttpApi.ApiEndpoint
 
   RestApiUrl:
     Value: !Sub https://${RestApi}.execute-api.${AWS::Region}.amazonaws.com/${StageApi}/

--- a/example/deployment/playbook.yml
+++ b/example/deployment/playbook.yml
@@ -106,6 +106,7 @@
   - name: debug
     debug:
       msg: |
+        Function URL at {{ site_stack_result.stack_outputs.FunctionUrl }}
         New style "HTTP API" using v2 events at {{ site_stack_result.stack_outputs.HttpApiUrl }}
         Old style REST API using v1 events at {{ site_stack_result.stack_outputs.RestApiUrl }}
         {% if site_stack_result.stack_outputs.AlbUrl %}ALB at http://{{ site_stack_result.stack_outputs.AlbUrl }}{% endif %}


### PR DESCRIPTION
A new feature appears ! https://aws.amazon.com/blogs/aws/announcing-aws-lambda-function-urls-built-in-https-endpoints-for-single-function-microservices/

...and apig-wsgi is ready for it.