### PR TITLE
Move from isort to reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,12 @@ repos:
   - id: blacken-docs
     additional_dependencies:
     - black==22.10.0
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v3.9.0
   hooks:
-  - id: isort
+  - id: reorder-python-imports
+    args:
+    - --py37-plus
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,10 @@ repos:
   - id: reorder-python-imports
     args:
     - --py37-plus
+    - --application-directories
+    - src:tests
+    - --add-import
+    - 'from __future__ import annotations'
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:

--- a/example/app/testapp/wsgi.py
+++ b/example/app/testapp/wsgi.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Any, cast
-
-from django.core.wsgi import get_wsgi_application
+from typing import Any
+from typing import cast
 
 from apig_wsgi import make_lambda_handler
 from apig_wsgi.compat import WSGIApplication
+from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "testapp.settings")
 

--- a/example/app/testapp/wsgi.py
+++ b/example/app/testapp/wsgi.py
@@ -5,9 +5,10 @@ import os
 from typing import Any
 from typing import cast
 
+from django.core.wsgi import get_wsgi_application
+
 from apig_wsgi import make_lambda_handler
 from apig_wsgi.compat import WSGIApplication
-from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "testapp.settings")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 target-version = ['py37']
 
-[tool.isort]
-profile = "black"
-add_imports = "from __future__ import annotations"
-
 [tool.mypy]
 mypy_path = "src/"
 show_error_codes = true

--- a/src/apig_wsgi/__init__.py
+++ b/src/apig_wsgi/__init__.py
@@ -2,11 +2,18 @@ from __future__ import annotations
 
 import sys
 import urllib
-from base64 import b64decode, b64encode
+from base64 import b64decode
+from base64 import b64encode
 from collections import defaultdict
 from io import BytesIO
 from types import TracebackType
-from typing import Any, Callable, Iterable, Sequence, Tuple, Type, Union
+from typing import Any
+from typing import Callable
+from typing import Iterable
+from typing import Sequence
+from typing import Tuple
+from typing import Type
+from typing import Union
 from urllib.parse import urlencode
 
 from apig_wsgi.compat import WSGIApplication

--- a/tests/test_apig_wsgi.py
+++ b/tests/test_apig_wsgi.py
@@ -9,6 +9,7 @@ from typing import Generator
 from typing import Iterable
 
 import pytest
+
 from apig_wsgi import _ExcInfoType
 from apig_wsgi import make_lambda_handler
 

--- a/tests/test_apig_wsgi.py
+++ b/tests/test_apig_wsgi.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import sys
 from base64 import b64encode
 from io import BytesIO
-from typing import Any, Callable, Generator, Iterable
+from typing import Any
+from typing import Callable
+from typing import Generator
+from typing import Iterable
 
 import pytest
-
-from apig_wsgi import _ExcInfoType, make_lambda_handler
+from apig_wsgi import _ExcInfoType
+from apig_wsgi import make_lambda_handler
 
 
 class App:


### PR DESCRIPTION
It’s [way faster](https://twitter.com/codewithanthony/status/1553034384206438401) and its one-import-per-line style prevents merge conflicts.
