### PR TITLE
Use rawPath rather than requestContext.http.path on v2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+* Avoid v2 trailing slash removal by reading ``rawPath`` rather than ``requestContext.http.path``.
+  This change prevents redirect loops on applications that automatically append slash, like Django’s default setup.
+
+  Thanks to Jon Culver for the report in `Issue #376 <https://github.com/adamchainz/apig-wsgi/issues/376>`__ and Tobias McNulty for the fix in `PR #426 <https://github.com/adamchainz/apig-wsgi/pull/426>`__.
+
 2.15.0 (2022-08-11)
 -------------------
 

--- a/example/app/testapp/urls.py
+++ b/example/app/testapp/urls.py
@@ -6,5 +6,6 @@ from testapp import views
 
 urlpatterns = [
     path("", views.index),
+    path("slashed/", views.index),
     path("favicon.ico", views.favicon),
 ]

--- a/src/apig_wsgi/__init__.py
+++ b/src/apig_wsgi/__init__.py
@@ -189,7 +189,7 @@ def get_environ_v2(
         "CONTENT_LENGTH": str(len(body)),
         "HTTP": "on",
         "HTTP_COOKIE": ";".join(event.get("cookies", ())),
-        "PATH_INFO": urllib.parse.unquote(http["path"], encoding="iso-8859-1"),
+        "PATH_INFO": urllib.parse.unquote(event["rawPath"], encoding="iso-8859-1"),
         "QUERY_STRING": event["rawQueryString"],
         "REMOTE_ADDR": http["sourceIp"],
         "REQUEST_METHOD": http["method"],

--- a/tests/test_apig_wsgi.py
+++ b/tests/test_apig_wsgi.py
@@ -675,12 +675,13 @@ def make_v2_event(
     event: dict[str, Any] = {
         "version": "2.0",
         "rawQueryString": query_string,
+        "rawPath": path,
         "headers": headers,
         "cookies": cookies,
         "requestContext": {
             "http": {
                 "method": method,
-                "path": path,
+                "path": path.rstrip("/"),
                 "sourceIp": "1.2.3.4",
                 "protocol": "https",
             },


### PR DESCRIPTION
Hi @adamchainz :)

When using the function URL directly, I hit the `/admin/` redirect loop mentioned in #376 as well, and confirmed things work again if I switch `get_environ_v2()` to use `event["rawPath"]` instead of `http["path"]`. I'm not if that makes sense in the grander scheme of things, but here's a small PR, if it makes sense to you.

Note that the admin works (no redirect loop) with and without this change when accessed via the v2 and ALB URLs.