### PR TITLE
Use isort to sort imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,16 +42,11 @@ repos:
   - id: blacken-docs
     additional_dependencies:
     - black==23.1.0
-- repo: https://github.com/asottile/reorder-python-imports
-  rev: v3.12.0
+- repo: https://github.com/pycqa/isort
+  rev: 5.13.2
   hooks:
-  - id: reorder-python-imports
-    args:
-    - --py38-plus
-    - --application-directories
-    - .:example/app:src
-    - --add-import
-    - 'from __future__ import annotations'
+    - id: isort
+      name: isort (python)
 - repo: https://github.com/PyCQA/flake8
   rev: 7.0.0
   hooks:

--- a/example/app/testapp/urls.py
+++ b/example/app/testapp/urls.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from django.urls import path
-
 from testapp import views
 
 urlpatterns = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,13 @@ Repository = "https://github.com/adamchainz/apig-wsgi"
 [tool.black]
 target-version = ['py38']
 
+[tool.isort]
+add_imports = [
+    "from __future__ import annotations"
+]
+force_single_line = true
+profile = "black"
+
 [tool.pytest.ini_options]
 addopts = """\
     --strict-config

--- a/src/apig_wsgi/compat.py
+++ b/src/apig_wsgi/compat.py
@@ -9,9 +9,14 @@ if sys.version_info >= (3, 11):
 else:
     # Partial backport of wsgiref.types
     from types import TracebackType
-    from typing import Any, Callable, Dict, Iterable, Tuple, Type, Union
-
+    from typing import Any
+    from typing import Callable
+    from typing import Dict
+    from typing import Iterable
     from typing import Protocol
+    from typing import Tuple
+    from typing import Type
+    from typing import Union
 
     _ExcInfo = Tuple[Type[BaseException], BaseException, TracebackType]
     _OptExcInfo = Union[_ExcInfo, Tuple[None, None, None]]


### PR DESCRIPTION
Switching because reorder-python-imports is incompatible with Black 24: https://github.com/asottile/reorder-python-imports/issues/366  / https://github.com/psf/black/issues/4175 .
