### PR TITLE
adds other compression types of encoding

### DIFF
--- a/src/apig_wsgi/__init__.py
+++ b/src/apig_wsgi/__init__.py
@@ -282,7 +282,11 @@ class BaseResponse:
 
         content_encoding = self._get_content_encoding()
         # Content type is non-binary but the content encoding might be.
-        return "gzip" in content_encoding.lower()
+        is_binary_content = any(
+            compression in content_encoding.lower()
+            for compression in ["gzip", "deflate", "br", "zstd"]
+        )
+        return is_binary_content
 
     def _get_content_type(self) -> str:
         return self._get_header("content-type") or ""


### PR DESCRIPTION
The dash app we used apig-wsgi to deploy to lambda had flask_compress enabled in the app which was using br encoding which wasn't being caught in the _should_send_binary.  